### PR TITLE
feat: 添加 GitHub Actions 自动 Release 工作流

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,67 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - "CLAUDE.md"
+      - "PROMPT.md"
+      - "README.md"
+      - ".gitignore"
+      - ".claude/**"
+      - ".github/**"
+      - "tests/**"
+      - "docs/**"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Extract version and generate tag
+        id: version
+        run: |
+          VERSION=$(grep -m1 '^version' pyproject.toml | sed 's/.*"\(.*\)".*/\1/')
+          SHORT_SHA=$(echo "$GITHUB_SHA" | cut -c1-7)
+          TAG="v${VERSION}-${SHORT_SHA}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Check if tag exists
+        id: check_tag
+        run: |
+          if git ls-remote --tags origin "refs/tags/${{ steps.version.outputs.tag }}" | grep -q .; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Package source
+        if: steps.check_tag.outputs.exists == 'false'
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          PREFIX="xiaohongshu-skills-${TAG}"
+          tar czf "${PREFIX}.tar.gz" \
+            --transform "s,^,${PREFIX}/," \
+            skills/ scripts/ SKILL.md pyproject.toml uv.lock LICENSE README.md
+          zip -r "${PREFIX}.zip" \
+            skills/ scripts/ SKILL.md pyproject.toml uv.lock LICENSE README.md \
+            -x '*.pyc' '__pycache__/*'
+
+      - name: Create GitHub Release
+        if: steps.check_tag.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          PREFIX="xiaohongshu-skills-${TAG}"
+          gh release create "$TAG" \
+            "${PREFIX}.tar.gz" \
+            "${PREFIX}.zip" \
+            --title "$TAG" \
+            --generate-notes


### PR DESCRIPTION
## Summary

- 新增 `.github/workflows/release.yml`，push 到 main 时自动创建 GitHub Release
- 使用 `paths-ignore` 排除文档/配置/测试/workflow 变更，避免无意义发版
- 从 `pyproject.toml` 提取版本号，Tag 格式 `v{version}-{short_sha}` 保证唯一
- Release 附带 `xiaohongshu-skills-{tag}.tar.gz` 和 `.zip` 源码产物（含 skills/、scripts/、SKILL.md、pyproject.toml、uv.lock、LICENSE、README.md）

## Test plan

- [ ] 合并后在 GitHub Actions 页面确认 workflow 运行成功
- [ ] 确认 Release 页面有新 release，包含正确 tag、notes 和 assets
- [ ] 修改 README.md 并 push，确认不会触发 release

🤖 Generated with [Claude Code](https://claude.com/claude-code)