### PR TITLE
fix: SKILL.md os 字段 macos 改为 darwin，修复 macOS 技能 blocked

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -13,7 +13,7 @@ metadata:
     emoji: "\U0001F4D5"
     homepage: https://github.com/xpzouying/xiaohongshu-skills
     os:
-      - macos
+      - darwin
       - linux
 ---
 

--- a/skills/xhs-auth/SKILL.md
+++ b/skills/xhs-auth/SKILL.md
@@ -12,7 +12,7 @@ metadata:
         - uv
     emoji: "\U0001F510"
     os:
-      - macos
+      - darwin
       - linux
 ---
 

--- a/skills/xhs-content-ops/SKILL.md
+++ b/skills/xhs-content-ops/SKILL.md
@@ -12,7 +12,7 @@ metadata:
         - uv
     emoji: "\U0001F4CA"
     os:
-      - macos
+      - darwin
       - linux
 ---
 

--- a/skills/xhs-explore/SKILL.md
+++ b/skills/xhs-explore/SKILL.md
@@ -12,7 +12,7 @@ metadata:
         - uv
     emoji: "\U0001F50D"
     os:
-      - macos
+      - darwin
       - linux
 ---
 

--- a/skills/xhs-interact/SKILL.md
+++ b/skills/xhs-interact/SKILL.md
@@ -12,7 +12,7 @@ metadata:
         - uv
     emoji: "\U0001F4AC"
     os:
-      - macos
+      - darwin
       - linux
 ---
 

--- a/skills/xhs-publish/SKILL.md
+++ b/skills/xhs-publish/SKILL.md
@@ -12,7 +12,7 @@ metadata:
         - uv
     emoji: "\U0001F4DD"
     os:
-      - macos
+      - darwin
       - linux
 ---
 


### PR DESCRIPTION
## 问题

所有 6 个技能在 macOS 上被 OpenClaw 标记为 **Missing requirements**，完全无法使用：

```
Missing requirements:
  📕 xiaohongshu-skills (os: macos, linux)
  🔐 xhs-auth (os: macos, linux)
  📊 xhs-content-ops (os: macos, linux)
  🔍 xhs-explore (os: macos, linux)
  💬 xhs-interact (os: macos, linux)
  📝 xhs-publish (os: macos, linux)
```

## 根因

SKILL.md 中 `metadata.openclaw.os` 字段使用了 `macos`，但 OpenClaw 内部通过 Node.js `process.platform` 进行平台匹配，macOS 对应的值是 **`darwin`** 而不是 `macos`。

参考 OpenClaw 官方内置技能（如 `apple-notes`、`imsg`）均使用 `"os": ["darwin"]`。

## 修改内容

将 6 个 SKILL.md 文件中的 `os: - macos` 改为 `os: - darwin`：

- `SKILL.md`
- `skills/xhs-auth/SKILL.md`
- `skills/xhs-content-ops/SKILL.md`
- `skills/xhs-explore/SKILL.md`
- `skills/xhs-interact/SKILL.md`
- `skills/xhs-publish/SKILL.md`

## 验证

修改后 `openclaw skills check` 确认所有 6 个技能状态从 Missing requirements 变为 Ready to use。

Closes #21