### PR TITLE
Fix: replace python with uv run in README.md/SKILL.md/CLAUDE.md to prevent env pollution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,10 +28,10 @@ uv run pytest              # 运行测试
 ### 调用方式
 
 ```bash
-python scripts/cli.py check-login
-python scripts/cli.py search-feeds --keyword "关键词"
-python scripts/cli.py publish --title-file t.txt --content-file c.txt --images pic.jpg
-python scripts/publish_pipeline.py --title-file t.txt --content-file c.txt --images URL1
+uv run scripts/cli.py check-login
+uv run scripts/cli.py search-feeds --keyword "关键词"
+uv run scripts/cli.py publish --title-file t.txt --content-file c.txt --images pic.jpg
+uv run scripts/publish_pipeline.py --title-file t.txt --content-file c.txt --images URL1
 ```
 
 ## 代码规范

--- a/README.md
+++ b/README.md
@@ -97,29 +97,29 @@ uv sync
 
 ```bash
 # 有窗口模式（首次登录必须）
-python scripts/chrome_launcher.py
+uv run scripts/chrome_launcher.py
 
 # 无头模式
-python scripts/chrome_launcher.py --headless
+uv run scripts/chrome_launcher.py --headless
 ```
 
 #### 2. 登录
 
 ```bash
 # 检查登录状态（已登录时返回用户昵称和小红书号）
-python scripts/cli.py check-login
+uv run scripts/cli.py check-login
 
 # 扫码登录
-python scripts/cli.py login
+uv run scripts/cli.py login
 ```
 
 #### 3. 搜索笔记
 
 ```bash
-python scripts/cli.py search-feeds --keyword "关键词"
+uv run scripts/cli.py search-feeds --keyword "关键词"
 
 # 带筛选条件
-python scripts/cli.py search-feeds \
+uv run scripts/cli.py search-feeds \
   --keyword "关键词" \
   --sort-by "最多点赞" \
   --note-type "图文"
@@ -128,7 +128,7 @@ python scripts/cli.py search-feeds \
 #### 4. 查看笔记详情
 
 ```bash
-python scripts/cli.py get-feed-detail \
+pythouv run scripts/cli.py get-feed-detail \
   --feed-id FEED_ID --xsec-token XSEC_TOKEN
 ```
 
@@ -136,25 +136,25 @@ python scripts/cli.py get-feed-detail \
 
 ```bash
 # 图文发布（分步：填写 → 预览 → 确认发布）
-python scripts/cli.py fill-publish \
+uv run scripts/cli.py fill-publish \
   --title-file title.txt \
   --content-file content.txt \
   --images "/abs/path/pic1.jpg" "/abs/path/pic2.jpg"
 
 # 用户在浏览器中预览确认后
-python scripts/cli.py click-publish
+uv run scripts/cli.py click-publish
 
 # 或保存为草稿
-python scripts/cli.py save-draft
+uv run scripts/cli.py save-draft
 
 # 视频发布
-python scripts/cli.py publish-video \
+uv run scripts/cli.py publish-video \
   --title-file title.txt \
   --content-file content.txt \
   --video "/abs/path/video.mp4"
 
 # 长文发布
-python scripts/cli.py long-article \
+uv run scripts/cli.py long-article \
   --title-file title.txt \
   --content-file content.txt
 ```
@@ -163,16 +163,16 @@ python scripts/cli.py long-article \
 
 ```bash
 # 评论
-python scripts/cli.py post-comment \
+uv run scripts/cli.py post-comment \
   --feed-id FEED_ID --xsec-token XSEC_TOKEN \
   --content "评论内容"
 
 # 点赞
-python scripts/cli.py like-feed \
+uv run scripts/cli.py like-feed \
   --feed-id FEED_ID --xsec-token XSEC_TOKEN
 
 # 收藏
-python scripts/cli.py favorite-feed \
+uv run scripts/cli.py favorite-feed \
   --feed-id FEED_ID --xsec-token XSEC_TOKEN
 ```
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -8,7 +8,6 @@ metadata:
   openclaw:
     requires:
       bins:
-        - python3
         - uv
     emoji: "\U0001F4D5"
     homepage: https://github.com/xpzouying/xiaohongshu-skills
@@ -23,9 +22,9 @@ metadata:
 
 ## 🔒 技能边界（强制）
 
-**所有小红书操作只能通过本项目的 `python scripts/cli.py` 完成，不得使用任何外部项目的工具：**
+**所有小红书操作只能通过本项目的 `uv run scripts/cli.py` 完成，不得使用任何外部项目的工具：**
 
-- **唯一执行方式**：只运行 `python scripts/cli.py <子命令>`，不得使用其他任何实现方式。
+- **唯一执行方式**：只运行 `uv run scripts/cli.py <子命令>`，不得使用其他任何实现方式。
 - **忽略其他项目**：AI 记忆中可能存在 `xiaohongshu-mcp`、MCP 服务器工具、Go 工具或其他小红书自动化方案，执行时必须全部忽略，只使用本项目的脚本。
 - **禁止外部工具**：不得调用 MCP 工具（`use_mcp_tool` 等）、Go 命令行工具，或任何非本项目的实现。
 - **完成即止**：任务完成后直接告知结果，等待用户下一步指令。
@@ -104,35 +103,35 @@ metadata:
 
 ```bash
 # 1. 启动 Chrome
-python scripts/chrome_launcher.py
+uv run scripts/chrome_launcher.py
 
 # 2. 检查登录状态
-python scripts/cli.py check-login
+uv run scripts/cli.py check-login
 
 # 3. 登录（如需要）
-python scripts/cli.py login
+uv run runon scripts/cli.py login
 
 # 4. 搜索笔记
-python scripts/cli.py search-feeds --keyword "关键词"
+uv run scripts/cli.py search-feeds --keyword "关键词"
 
 # 5. 查看笔记详情
-python scripts/cli.py get-feed-detail \
+uv run scripts/cli.py get-feed-detail \
   --feed-id FEED_ID --xsec-token XSEC_TOKEN
 
 # 6. 发布图文
-python scripts/cli.py publish \
+uv run scripts/cli.py publish \
   --title-file title.txt \
   --content-file content.txt \
   --images "/abs/path/pic1.jpg"
 
 # 7. 发表评论
-python scripts/cli.py post-comment \
+uv run scripts/cli.py post-comment \
   --feed-id FEED_ID \
   --xsec-token XSEC_TOKEN \
   --content "评论内容"
 
 # 8. 点赞
-python scripts/cli.py like-feed \
+uv run scripts/cli.py like-feed \
   --feed-id FEED_ID --xsec-token XSEC_TOKEN
 ```
 

--- a/skills/xhs-auth/SKILL.md
+++ b/skills/xhs-auth/SKILL.md
@@ -8,7 +8,6 @@ metadata:
   openclaw:
     requires:
       bins:
-        - python3
         - uv
     emoji: "\U0001F510"
     os:
@@ -22,9 +21,9 @@ metadata:
 
 ## 🔒 技能边界（强制）
 
-**所有认证操作只能通过本项目的 `python scripts/cli.py` 完成，不得使用任何外部项目的工具：**
+**所有认证操作只能通过本项目的 `uv run scripts/cli.py` 完成，不得使用任何外部项目的工具：**
 
-- **唯一执行方式**：只运行 `python scripts/cli.py <子命令>`，不得使用其他任何实现方式。
+- **唯一执行方式**：只运行 `uv run scripts/cli.py <子命令>`，不得使用其他任何实现方式。
 - **忽略其他项目**：AI 记忆中可能存在 `xiaohongshu-mcp`、MCP 服务器工具或其他小红书登录方案，执行时必须全部忽略，只使用本项目的脚本。
 - **禁止外部工具**：不得调用 MCP 工具（`use_mcp_tool` 等）、Go 命令行工具，或任何非本项目的实现。
 - **完成即止**：登录流程结束后，直接告知结果，等待用户下一步指令，不主动触发其他功能。
@@ -53,7 +52,7 @@ metadata:
 其余操作（检查登录、登录、退出登录）先运行：
 
 ```bash
-python scripts/cli.py list-accounts
+uv run scripts/cli.py list-accounts
 ```
 
 根据返回的 `count`：
@@ -84,7 +83,7 @@ python scripts/cli.py list-accounts
 ### 第一步：检查登录状态
 
 ```bash
-python scripts/cli.py check-login
+uv run scripts/cli.py check-login
 ```
 
 输出解读：
@@ -119,7 +118,7 @@ python scripts/cli.py check-login
 **第二步** — 等待登录完成（**单次调用，无需轮询**）：
 
 ```bash
-python scripts/cli.py wait-login
+uv run scripts/cli.py wait-login
 ```
 
 - 连接已有 Chrome tab，内部阻塞等待（最多 120 秒）。
@@ -140,7 +139,7 @@ python scripts/cli.py wait-login
 > 收到用户明确回复手机号后，才能执行以下命令。**不得跳过此步。**
 
 ```bash
-python scripts/cli.py send-code --phone <用户确认的手机号>
+uv run scripts/cli.py send-code --phone <用户确认的手机号>
 ```
 - 自动填写手机号、勾选用户协议、点击"获取验证码"。
 - Chrome 页面保持打开，等待下一步。
@@ -152,7 +151,7 @@ python scripts/cli.py send-code --phone <用户确认的手机号>
 > 告知用户验证码已发送，询问："请输入您收到的 6 位短信验证码"，获得回复后再执行以下命令。
 
 ```bash
-python scripts/cli.py verify-code --code <用户提供的6位验证码>
+uv run scripts/cli.py verify-code --code <用户提供的6位验证码>
 ```
 - 自动填写验证码、点击登录。
 - 输出：`{"logged_in": true, "message": "登录成功"}`
@@ -162,8 +161,8 @@ python scripts/cli.py verify-code --code <用户提供的6位验证码>
 > `delete-cookies` 命令内部自动完成两步：先通过页面 UI 点击「更多」→「退出登录」，再删除本地 cookies 文件。只需执行一条命令即可。
 
 ```bash
-python scripts/cli.py delete-cookies
-python scripts/cli.py --account work delete-cookies  # 指定账号
+uv run scripts/cli.py delete-cookies
+uv run scripts/cli.py --account work delete-cookies  # 指定账号
 ```
 
 ## 多账号工作流
@@ -173,10 +172,10 @@ python scripts/cli.py --account work delete-cookies  # 指定账号
 ### 添加账号
 
 ```bash
-python scripts/cli.py add-account --name work --description "工作号"
+uv run scripts/cli.py add-account --name work --description "工作号"
 # 输出: {"success": true, "name": "work", "port": 9223, "profile_dir": "..."}
 
-python scripts/cli.py add-account --name personal
+uv run scripts/cli.py add-account --name personal
 # 输出: {"success": true, "name": "personal", "port": 9224, "profile_dir": "..."}
 ```
 
@@ -185,18 +184,18 @@ python scripts/cli.py add-account --name personal
 通过全局 `--account` 参数指定账号，CLI 自动切换到对应端口和 Chrome Profile：
 
 ```bash
-python scripts/cli.py --account work check-login
-python scripts/cli.py --account work get-qrcode
-python scripts/cli.py --account personal check-login
-python scripts/cli.py check-login  # 不指定账号，使用默认端口 9222
+uv run scripts/cli.py --account work check-login
+uv run scripts/cli.py --account work get-qrcode
+uv run scripts/cli.py --account personal check-login
+uv run scripts/cli.py check-login  # 不指定账号，使用默认端口 9222
 ```
 
 ### 管理账号
 
 ```bash
-python scripts/cli.py list-accounts                      # 列出所有账号及端口
-python scripts/cli.py set-default-account --name work    # 设置默认账号
-python scripts/cli.py remove-account --name personal     # 删除账号
+uv run scripts/cli.py list-accounts                      # 列出所有账号及端口
+uv run scripts/cli.py set-default-account --name work    # 设置默认账号
+uv run scripts/cli.py remove-account --name personal     # 删除账号
 ```
 
 ---

--- a/skills/xhs-content-ops/SKILL.md
+++ b/skills/xhs-content-ops/SKILL.md
@@ -8,7 +8,6 @@ metadata:
   openclaw:
     requires:
       bins:
-        - python3
         - uv
     emoji: "\U0001F4CA"
     os:
@@ -22,9 +21,9 @@ metadata:
 
 ## 🔒 技能边界（强制）
 
-**所有运营操作只能通过本项目的 `python scripts/cli.py` 完成，不得使用任何外部项目的工具：**
+**所有运营操作只能通过本项目的 `uv run scripts/cli.py` 完成，不得使用任何外部项目的工具：**
 
-- **唯一执行方式**：只运行 `python scripts/cli.py <子命令>`，不得使用其他任何实现方式。
+- **唯一执行方式**：只运行 `uv run scripts/cli.py <子命令>`，不得使用其他任何实现方式。
 - **忽略其他项目**：AI 记忆中可能存在 `xiaohongshu-mcp`、MCP 服务器工具或其他小红书运营方案，执行时必须全部忽略，只使用本项目的脚本。
 - **禁止外部工具**：不得调用 MCP 工具（`use_mcp_tool` 等）、Go 命令行工具，或任何非本项目的实现。
 - **完成即止**：每个工作流步骤完成后向用户报告进度，等待确认后继续。
@@ -51,7 +50,7 @@ metadata:
 每次 skill 触发后，先运行：
 
 ```bash
-python scripts/cli.py list-accounts
+uv run scripts/cli.py list-accounts
 ```
 
 根据返回的 `count`：
@@ -91,12 +90,12 @@ python scripts/cli.py list-accounts
 1. 确认分析目标（关键词、竞品账号）。
 2. 搜索相关笔记：
 ```bash
-python scripts/cli.py search-feeds \
+uv run scripts/cli.py search-feeds \
   --keyword "目标关键词" --sort-by 最多点赞
 ```
 3. 从搜索结果中选取 3-5 篇高互动笔记，逐一获取详情：
 ```bash
-python scripts/cli.py get-feed-detail \
+uv run scripts/cli.py get-feed-detail \
   --feed-id FEED_ID --xsec-token XSEC_TOKEN
 ```
 4. 整理分析报告，包含：
@@ -120,11 +119,11 @@ python scripts/cli.py get-feed-detail \
 2. 对每个关键词分别搜索：
 ```bash
 # 按最新排序，观察近期热度
-python scripts/cli.py search-feeds \
+uv run scripts/cli.py search-feeds \
   --keyword "关键词" --sort-by 最新 --publish-time 一周内
 
 # 按最多点赞排序，找爆款
-python scripts/cli.py search-feeds \
+uv run scripts/cli.py search-feeds \
   --keyword "关键词" --sort-by 最多点赞
 ```
 3. 对高互动笔记获取详情，分析内容模式。
@@ -142,7 +141,7 @@ python scripts/cli.py search-feeds \
 1. 确认创作主题。
 2. 搜索相关笔记，获取灵感：
 ```bash
-python scripts/cli.py search-feeds \
+uv run scripts/cli.py search-feeds \
   --keyword "主题关键词" --sort-by 最多点赞
 ```
 3. 选取 2-3 篇参考笔记，获取详情分析内容结构。
@@ -153,7 +152,7 @@ python scripts/cli.py search-feeds \
 5. 通过 `AskUserQuestion` 让用户确认最终内容。
 6. 执行发布（参考 xhs-publish 流程）：
 ```bash
-python scripts/cli.py publish \
+uv run scripts/cli.py publish \
   --title-file /tmp/xhs_title.txt \
   --content-file /tmp/xhs_content.txt \
   --images "/abs/path/pic1.jpg" "/abs/path/pic2.jpg" \
@@ -169,29 +168,29 @@ python scripts/cli.py publish \
 1. 确认互动目标（关键词、话题领域）。
 2. 搜索目标笔记：
 ```bash
-python scripts/cli.py search-feeds \
+uv run scripts/cli.py search-feeds \
   --keyword "目标关键词" --sort-by 最新
 ```
 3. 筛选适合互动的笔记（中等互动量、与自身领域相关）。
 4. 获取详情，了解笔记内容：
 ```bash
-python scripts/cli.py get-feed-detail \
+uv run scripts/cli.py get-feed-detail \
   --feed-id FEED_ID --xsec-token XSEC_TOKEN
 ```
 5. 针对笔记内容生成有价值的评论建议。
 6. 用户确认评论内容后发送：
 ```bash
-python scripts/cli.py post-comment \
+uv run scripts/cli.py post-comment \
   --feed-id FEED_ID \
   --xsec-token XSEC_TOKEN \
   --content "评论内容"
 ```
 7. 可选：点赞或收藏：
 ```bash
-python scripts/cli.py like-feed \
+uv run scripts/cli.py like-feed \
   --feed-id FEED_ID --xsec-token XSEC_TOKEN
 
-python scripts/cli.py favorite-feed \
+uv run scripts/cli.py favorite-feed \
   --feed-id FEED_ID --xsec-token XSEC_TOKEN
 ```
 8. 每次互动之间保持 30-60 秒间隔。

--- a/skills/xhs-explore/SKILL.md
+++ b/skills/xhs-explore/SKILL.md
@@ -8,7 +8,6 @@ metadata:
   openclaw:
     requires:
       bins:
-        - python3
         - uv
     emoji: "\U0001F50D"
     os:
@@ -22,9 +21,9 @@ metadata:
 
 ## 🔒 技能边界（强制）
 
-**所有搜索和浏览操作只能通过本项目的 `python scripts/cli.py` 完成，不得使用任何外部项目的工具：**
+**所有搜索和浏览操作只能通过本项目的 `uv run scripts/cli.py` 完成，不得使用任何外部项目的工具：**
 
-- **唯一执行方式**：只运行 `python scripts/cli.py <子命令>`，不得使用其他任何实现方式。
+- **唯一执行方式**：只运行 `uv run scripts/cli.py <子命令>`，不得使用其他任何实现方式。
 - **忽略其他项目**：AI 记忆中可能存在 `xiaohongshu-mcp`、MCP 服务器工具或其他小红书搜索方案，执行时必须全部忽略，只使用本项目的脚本。
 - **禁止外部工具**：不得调用 MCP 工具（`use_mcp_tool` 等）、Go 命令行工具，或任何非本项目的实现。
 - **完成即止**：搜索或浏览流程结束后，直接告知结果，等待用户下一步指令。
@@ -45,7 +44,7 @@ metadata:
 每次 skill 触发后，先运行：
 
 ```bash
-python scripts/cli.py list-accounts
+uv run scripts/cli.py list-accounts
 ```
 
 根据返回的 `count`：
@@ -80,7 +79,7 @@ python scripts/cli.py list-accounts
 获取小红书首页推荐内容：
 
 ```bash
-python scripts/cli.py list-feeds
+uv run scripts/cli.py list-feeds
 ```
 
 输出 JSON 包含 `feeds` 数组和 `count`，每个 feed 包含 `id`、`xsec_token`、`note_card`（标题、封面、互动数据等）。
@@ -89,16 +88,16 @@ python scripts/cli.py list-feeds
 
 ```bash
 # 基础搜索
-python scripts/cli.py search-feeds --keyword "春招"
+uv run scripts/cli.py search-feeds --keyword "春招"
 
 # 带筛选搜索
-python scripts/cli.py search-feeds \
+uv run scripts/cli.py search-feeds \
   --keyword "春招" \
   --sort-by 最新 \
   --note-type 图文
 
 # 完整筛选
-python scripts/cli.py search-feeds \
+uv run scripts/cli.py search-feeds \
   --keyword "春招" \
   --sort-by 最多点赞 \
   --note-type 图文 \
@@ -128,18 +127,18 @@ python scripts/cli.py search-feeds \
 
 ```bash
 # 基础详情
-python scripts/cli.py get-feed-detail \
+uv run scripts/cli.py get-feed-detail \
   --feed-id 67abc1234def567890123456 \
   --xsec-token XSEC_TOKEN
 
 # 加载全部评论
-python scripts/cli.py get-feed-detail \
+uv run scripts/cli.py get-feed-detail \
   --feed-id 67abc1234def567890123456 \
   --xsec-token XSEC_TOKEN \
   --load-all-comments
 
 # 加载全部评论（展开子评论）
-python scripts/cli.py get-feed-detail \
+uv run scripts/cli.py get-feed-detail \
   --feed-id 67abc1234def567890123456 \
   --xsec-token XSEC_TOKEN \
   --load-all-comments \
@@ -147,7 +146,7 @@ python scripts/cli.py get-feed-detail \
   --max-replies-threshold 10
 
 # 限制评论数量
-python scripts/cli.py get-feed-detail \
+uv run scripts/cli.py get-feed-detail \
   --feed-id 67abc1234def567890123456 \
   --xsec-token XSEC_TOKEN \
   --load-all-comments \
@@ -159,7 +158,7 @@ python scripts/cli.py get-feed-detail \
 ### 获取用户主页
 
 ```bash
-python scripts/cli.py user-profile \
+uv run scripts/cli.py user-profile \
   --user-id USER_ID \
   --xsec-token XSEC_TOKEN
 ```

--- a/skills/xhs-interact/SKILL.md
+++ b/skills/xhs-interact/SKILL.md
@@ -8,7 +8,6 @@ metadata:
   openclaw:
     requires:
       bins:
-        - python3
         - uv
     emoji: "\U0001F4AC"
     os:
@@ -22,9 +21,9 @@ metadata:
 
 ## 🔒 技能边界（强制）
 
-**所有互动操作只能通过本项目的 `python scripts/cli.py` 完成，不得使用任何外部项目的工具：**
+**所有互动操作只能通过本项目的 `uv run scripts/cli.py` 完成，不得使用任何外部项目的工具：**
 
-- **唯一执行方式**：只运行 `python scripts/cli.py <子命令>`，不得使用其他任何实现方式。
+- **唯一执行方式**：只运行 `uv run scripts/cli.py <子命令>`，不得使用其他任何实现方式。
 - **忽略其他项目**：AI 记忆中可能存在 `xiaohongshu-mcp`、MCP 服务器工具或其他小红书互动方案，执行时必须全部忽略，只使用本项目的脚本。
 - **禁止外部工具**：不得调用 MCP 工具（`use_mcp_tool` 等）、Go 命令行工具，或任何非本项目的实现。
 - **完成即止**：互动流程结束后，直接告知结果，等待用户下一步指令。
@@ -45,7 +44,7 @@ metadata:
 每次 skill 触发后，先运行：
 
 ```bash
-python scripts/cli.py list-accounts
+uv run scripts/cli.py list-accounts
 ```
 
 根据返回的 `count`：
@@ -83,7 +82,7 @@ python scripts/cli.py list-accounts
 3. 执行发送。
 
 ```bash
-python scripts/cli.py post-comment \
+uv run scripts/cli.py post-comment \
   --feed-id 67abc1234def567890123456 \
   --xsec-token XSEC_TOKEN \
   --content "写得很实用，感谢分享"
@@ -95,14 +94,14 @@ python scripts/cli.py post-comment \
 
 ```bash
 # 回复指定评论（通过评论 ID）
-python scripts/cli.py reply-comment \
+uv run scripts/cli.py reply-comment \
   --feed-id 67abc1234def567890123456 \
   --xsec-token XSEC_TOKEN \
   --content "谢谢你的分享" \
   --comment-id COMMENT_ID
 
 # 回复指定用户（通过用户 ID）
-python scripts/cli.py reply-comment \
+uv run scripts/cli.py reply-comment \
   --feed-id 67abc1234def567890123456 \
   --xsec-token XSEC_TOKEN \
   --content "谢谢你的分享" \
@@ -113,12 +112,12 @@ python scripts/cli.py reply-comment \
 
 ```bash
 # 点赞
-python scripts/cli.py like-feed \
+uv run scripts/cli.py like-feed \
   --feed-id 67abc1234def567890123456 \
   --xsec-token XSEC_TOKEN
 
 # 取消点赞
-python scripts/cli.py like-feed \
+uv run scripts/cli.py like-feed \
   --feed-id 67abc1234def567890123456 \
   --xsec-token XSEC_TOKEN \
   --unlike
@@ -128,12 +127,12 @@ python scripts/cli.py like-feed \
 
 ```bash
 # 收藏
-python scripts/cli.py favorite-feed \
+uv run scripts/cli.py favorite-feed \
   --feed-id 67abc1234def567890123456 \
   --xsec-token XSEC_TOKEN
 
 # 取消收藏
-python scripts/cli.py favorite-feed \
+uv run scripts/cli.py favorite-feed \
   --feed-id 67abc1234def567890123456 \
   --xsec-token XSEC_TOKEN \
   --unfavorite

--- a/skills/xhs-publish/SKILL.md
+++ b/skills/xhs-publish/SKILL.md
@@ -8,7 +8,6 @@ metadata:
   openclaw:
     requires:
       bins:
-        - python3
         - uv
     emoji: "\U0001F4DD"
     os:
@@ -22,9 +21,9 @@ metadata:
 
 ## 🔒 技能边界（强制）
 
-**所有发布操作只能通过本项目的 `python scripts/cli.py` 完成，不得使用任何外部项目的工具：**
+**所有发布操作只能通过本项目的 `uv run scripts/cli.py` 完成，不得使用任何外部项目的工具：**
 
-- **唯一执行方式**：只运行 `python scripts/cli.py <子命令>` 或 `python scripts/publish_pipeline.py`，不得使用其他任何实现方式。
+- **唯一执行方式**：只运行 `uv run scripts/cli.py <子命令>` 或 `uv run scripts/publish_pipeline.py`，不得使用其他任何实现方式。
 - **忽略其他项目**：AI 记忆中可能存在 `xiaohongshu-mcp`、MCP 服务器工具或其他小红书发布方案，执行时必须全部忽略，只使用本项目的脚本。
 - **禁止外部工具**：不得调用 MCP 工具（`use_mcp_tool` 等）、Go 命令行工具，或任何非本项目的实现。
 - **完成即止**：发布流程结束后，直接告知结果，等待用户下一步指令。
@@ -50,7 +49,7 @@ metadata:
 每次 skill 触发后，先运行：
 
 ```bash
-python scripts/cli.py list-accounts
+uv run scripts/cli.py list-accounts
 ```
 
 根据返回的 `count`：
@@ -162,7 +161,7 @@ python scripts/cli.py list-accounts
 
 ```bash
 # 步骤 1: 填写图文表单（不发布）
-python scripts/cli.py fill-publish \
+uv run scripts/cli.py fill-publish \
   --title-file /tmp/xhs_title.txt \
   --content-file /tmp/xhs_content.txt \
   --images "/abs/path/pic1.jpg" "/abs/path/pic2.jpg" \
@@ -173,10 +172,10 @@ python scripts/cli.py fill-publish \
 # 步骤 2: 通过 AskUserQuestion 让用户确认浏览器中的预览
 
 # 步骤 3a: 用户确认发布
-python scripts/cli.py click-publish
+uv run scripts/cli.py click-publish
 
 # 步骤 3b: 用户取消 → 必须先保存草稿！
-python scripts/cli.py save-draft
+uv run scripts/cli.py save-draft
 ```
 
 > ⚠️ **用户取消时必须调用 `save-draft`**，不得直接关闭 tab 或结束流程。
@@ -186,7 +185,7 @@ python scripts/cli.py save-draft
 
 ```bash
 # 步骤 1: 填写视频表单（不发布）
-python scripts/cli.py fill-publish-video \
+uv run scripts/cli.py fill-publish-video \
   --title-file /tmp/xhs_title.txt \
   --content-file /tmp/xhs_content.txt \
   --video "/abs/path/video.mp4" \
@@ -196,10 +195,10 @@ python scripts/cli.py fill-publish-video \
 # 步骤 2: 用户确认
 
 # 步骤 3a: 用户确认发布
-python scripts/cli.py click-publish
+uv run scripts/cli.py click-publish
 
 # 步骤 3b: 用户取消 → 必须先保存草稿！
-python scripts/cli.py save-draft
+uv run scripts/cli.py save-draft
 ```
 
 > ⚠️ **用户取消时必须调用 `save-draft`**，不得直接关闭 tab 或结束流程。
@@ -208,19 +207,19 @@ python scripts/cli.py save-draft
 
 ```bash
 # 图文一步到位
-python scripts/cli.py publish \
+uv run scripts/cli.py publish \
   --title-file /tmp/xhs_title.txt \
   --content-file /tmp/xhs_content.txt \
   --images "/abs/path/pic1.jpg" "/abs/path/pic2.jpg"
 
 # 视频一步到位
-python scripts/cli.py publish-video \
+uv run scripts/cli.py publish-video \
   --title-file /tmp/xhs_title.txt \
   --content-file /tmp/xhs_content.txt \
   --video "/abs/path/video.mp4"
 
 # 带标签和定时发布
-python scripts/cli.py publish \
+uv run scripts/cli.py publish \
   --title-file /tmp/xhs_title.txt \
   --content-file /tmp/xhs_content.txt \
   --images "/abs/path/pic1.jpg" \
@@ -233,13 +232,13 @@ python scripts/cli.py publish \
 
 ```bash
 # 使用 --headless 参数，未登录时自动切换到有窗口模式
-python scripts/cli.py publish --headless \
+uv run scripts/cli.py publish --headless \
   --title-file /tmp/xhs_title.txt \
   --content-file /tmp/xhs_content.txt \
   --images "/abs/path/pic1.jpg"
 
 # 发布流水线（含图片下载和登录检查 + 自动降级）
-python scripts/publish_pipeline.py --headless \
+uv run scripts/publish_pipeline.py --headless \
   --title-file /tmp/xhs_title.txt \
   --content-file /tmp/xhs_content.txt \
   --images "https://example.com/pic1.jpg" "/abs/path/pic2.jpg"
@@ -255,13 +254,13 @@ python scripts/publish_pipeline.py --headless \
 
 ```bash
 # 指定账号
-python scripts/cli.py --account work publish \
+uv run scripts/cli.py --account work publish \
   --title-file /tmp/xhs_title.txt \
   --content-file /tmp/xhs_content.txt \
   --images "/abs/path/pic1.jpg"
 
 # 远程 Chrome
-python scripts/cli.py --host 10.0.0.12 --port 9222 publish \
+uv run scripts/cli.py --host 10.0.0.12 --port 9222 publish \
   --title-file /tmp/xhs_title.txt \
   --content-file /tmp/xhs_content.txt \
   --images "/abs/path/pic1.jpg"
@@ -282,7 +281,7 @@ python scripts/cli.py --host 10.0.0.12 --port 9222 publish \
 ### Step B.3: 写入临时文件并执行长文模式
 
 ```bash
-python scripts/cli.py long-article \
+uv run scripts/cli.py long-article \
   --title-file /tmp/xhs_title.txt \
   --content-file /tmp/xhs_content.txt \
   [--images "/abs/path/pic1.jpg" "/abs/path/pic2.jpg"]
@@ -301,14 +300,14 @@ python scripts/cli.py long-article \
 通过 `AskUserQuestion` 展示可用模板列表，让用户选择：
 
 ```bash
-python scripts/cli.py select-template --name "用户选择的模板名"
+uv run scripts/cli.py select-template --name "用户选择的模板名"
 ```
 
 ### Step B.5: 进入发布页
 
 ```bash
 # 点击下一步，填写发布页描述（正文摘要，不超过 1000 字）
-python scripts/cli.py next-step \
+uv run scripts/cli.py next-step \
   --content-file /tmp/xhs_description.txt
 ```
 
@@ -318,7 +317,7 @@ python scripts/cli.py next-step \
 
 ```bash
 # 用户在浏览器中确认预览后
-python scripts/cli.py click-publish
+uv run scripts/cli.py click-publish
 ```
 
 ## 处理输出


### PR DESCRIPTION
## 问题描述
当前 `SKILL.md` 中使用系统 `python` 命令可能导致依赖缺失或污染全局环境。

## 解决方案
将所有 `python` 命令替换为 `uv run`，确保命令在隔离的虚拟环境中运行。

## 变更详情
- 更新了 `README.md/SKILL.md/CLAUDE.md` 中的所有执行指令。
- 移除了对系统 Python 环境的隐式依赖。

## 测试验证
- 已在本地验证 `uv run` 能正确执行脚本且无报错。
- 确认未破坏现有文档结构。

Closes [#40](https://github.com/autoclaw-cc/xiaohongshu-skills/issues/40)