### PR TITLE
fix: 修复 WSL 环境下多图上传导致 Chrome 崩溃的问题

### DIFF
--- a/scripts/xhs/cdp.py
+++ b/scripts/xhs/cdp.py
@@ -69,6 +69,11 @@ class Page:
         self._ws = cdp._ws
         self._id_counter = 1000
 
+    def is_chrome_on_windows(self) -> bool:
+        """返回 Chrome 是否运行在 Windows 上（通过 navigator.userAgent 检测）。"""
+        ua = self.evaluate("navigator.userAgent") or ""
+        return "Windows" in ua
+
     def _send_session(self, method: str, params: dict | None = None) -> dict:
         """向 session 发送命令。"""
         self._id_counter += 1
@@ -535,7 +540,9 @@ class Page:
         try:
             doc = self._send_session("DOM.getDocument", {"depth": 0})
             root_id = doc["root"]["nodeId"]
-            query = self._send_session("DOM.querySelector", {"nodeId": root_id, "selector": selector})
+            query = self._send_session(
+                "DOM.querySelector", {"nodeId": root_id, "selector": selector}
+            )
             node_id = query.get("nodeId", 0)
             if not node_id:
                 return b""

--- a/scripts/xhs/publish.py
+++ b/scripts/xhs/publish.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import json
 import logging
+import platform
 import random
 import re
+import subprocess
 import time
 
 from .cdp import Page
@@ -245,21 +247,75 @@ def _remove_pop_cover(page: Page) -> None:
 # ========== 图片上传 ==========
 
 
+def _convert_to_windows_path(path: str, page: Page) -> str:
+    r"""将路径转换为 Windows 路径格式（用于 Chrome on Windows）。
+
+    仅在以下两个条件同时满足时转换路径：
+    1. 脚本运行在 WSL 环境下
+    2. Chrome 运行在 Windows 上（通过 User-Agent 检测）
+
+    Args:
+        path: 原始路径（可能是 WSL 或 Windows 路径）。
+        page: CDP 页面对象，用于检测 Chrome 平台。
+
+    Returns:
+        Chrome 可以访问的路径（需要转换时为 Windows 路径，否则保持原样）。
+    """
+    # 检查 Chrome 是否运行在 Windows 上
+    if not page.is_chrome_on_windows():
+        return path
+
+    # 非 Linux 平台直接返回原路径
+    if platform.system() != "Linux":
+        return path
+
+    # 检查是否为 WSL 环境
+    try:
+        with open("/proc/version", "r") as f:
+            proc_version = f.read().lower()
+            is_wsl = "microsoft" in proc_version
+    except Exception:
+        is_wsl = False
+
+    if not is_wsl:
+        return path
+
+    # WSL + Windows Chrome：使用 wslpath 转换为 Windows 路径
+    try:
+        result = subprocess.run(
+            ["wslpath", "-w", path],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        windows_path = result.stdout.strip()
+        logger.debug("路径转换 (WSL->Windows): %s -> %s", path, windows_path)
+        return windows_path
+    except subprocess.CalledProcessError:
+        logger.warning("wslpath 转换失败，使用原路径: %s", path)
+        return path
+    except FileNotFoundError:
+        logger.warning("未找到 wslpath 命令，使用原路径: %s", path)
+        return path
+
+
 def _upload_images(page: Page, image_paths: list[str]) -> None:
-    """逐张上传图片。"""
+    """批量上传图片（利用 input[multiple] 特性一次性上传所有文件）。
+
+    在 WSL + Windows Chrome 环境下自动将 Linux 路径转换为 Windows 路径。
+    """
     import os
 
     valid_paths = [p for p in image_paths if os.path.exists(p)]
     if not valid_paths:
         raise PublishError("没有有效的图片文件")
 
-    for i, path in enumerate(valid_paths):
-        selector = UPLOAD_INPUT if i == 0 else FILE_INPUT
-        logger.info("上传第 %d 张图片: %s", i + 1, path)
+    # 根据环境自动转换路径（WSL + Windows Chrome 时转换为 Windows 路径）
+    converted_paths = [_convert_to_windows_path(p, page) for p in valid_paths]
 
-        page.set_file_input(selector, [path])
-        _wait_for_upload_complete(page, i + 1)
-        time.sleep(1)
+    logger.info("批量上传 %d 张图片", len(converted_paths))
+    page.set_file_input(UPLOAD_INPUT, converted_paths)
+    _wait_for_upload_complete(page, len(converted_paths))
 
 
 def _wait_for_upload_complete(page: Page, expected_count: int) -> None:


### PR DESCRIPTION
## 问题

在 WSL 环境下运行脚本，Chrome 运行在 Windows 上时，多图上传会导致 Chrome 标签页崩溃：

- **崩溃错误**: `RESULT_CODE_KILLED_BAD_MESSAGE`
- **网络错误**: `GET blob:https://creator.xiaohongshu.com/... net::ERR_BLOB_REFERENCED_FILE_UNAVAILABLE`

### 根本原因

1. **跨文件系统边界**: 脚本在 WSL 中运行（路径格式 `/home/xxx/...`），但 Chrome 运行在 Windows 上
2. **Chrome 无法访问 WSL 路径**: 当 `DOM.setFileInputFiles` 使用 WSL 路径时，创建的 blob URL 无法被 Chrome 访问
3. **多次调用问题**: 原代码逐张上传，每次都调用 `DOM.setFileInputFiles`，加剧了问题

## 解决方案

### 1. 平台检测 (`scripts/xhs/cdp.py`)

新增 `Page.is_chrome_on_windows()` 方法，通过 `navigator.userAgent` 检测 Chrome 运行平台：

```python
def is_chrome_on_windows(self) -> bool:
    """返回 Chrome 是否运行在 Windows 上（通过 navigator.userAgent 检测）。"""
    ua = self.evaluate("navigator.userAgent") or ""
    return "Windows" in ua
```

### 2. 路径转换 (`scripts/xhs/publish.py`)

新增 `_convert_to_windows_path()` 函数，在 WSL + Windows Chrome 环境下自动转换路径：

```python
def _convert_to_windows_path(path: str, page: Page) -> str:
    # 检查 Chrome 是否运行在 Windows 上
    if not page.is_chrome_on_windows():
        return path
    
    # 检查是否为 WSL 环境
    is_wsl = "microsoft" in open("/proc/version").read().lower()
    if not is_wsl:
        return path
    
    # 使用 wslpath 转换: /home/xxx/... → \\wsl.localhost\Ubuntu\home\xxx\...
    return subprocess.run(["wslpath", "-w", path], ...).stdout.strip()
```

### 3. 批量上传 (`scripts/xhs/publish.py`)

改用 `input[type="file"][multiple]` 特性一次性上传所有文件：

```python
# 之前：逐张上传
for i, path in enumerate(valid_paths):
    page.set_file_input(selector, [path])
    _wait_for_upload_complete(page, i + 1)

# 现在：批量上传
converted_paths = [_convert_to_windows_path(p, page) for p in valid_paths]
page.set_file_input(UPLOAD_INPUT, converted_paths)
_wait_for_upload_complete(page, len(converted_paths))
```

## 兼容性

该修复支持所有环境组合：

| 脚本环境 | Chrome 位置 | 路径转换 | 说明 |
|---------|------------|---------|------|
| WSL | Windows | ✅ 是 | 你的情况，自动转换路径 |
| WSL | WSL/Linux | ❌ 否 | Chrome 在 WSL 内，无需转换 |
| Linux | Linux | ❌ 否 | 原生 Linux，无需转换 |
| Windows | Windows | ❌ 否 | 原生 Windows，无需转换 |
| macOS | macOS | ❌ 否 | 原生 macOS，无需转换 |

## 测试

```bash
# WSL 环境测试
uv run scripts/cli.py fill-publish \
  --title-file title.txt \
  --content-file content.txt \
  --images "/home/xxx/image1.jpg" "/home/xxx/image2.jpg"
```

✅ 多图上传成功，无 Chrome 崩溃