### PR TITLE
fix: Chrome 进程使用独立 session 避免被父进程组回收

### DIFF
--- a/scripts/chrome_launcher.py
+++ b/scripts/chrome_launcher.py
@@ -158,6 +158,7 @@ def launch_chrome(
         args,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
+        start_new_session=True,
     )
     _chrome_process = process
 


### PR DESCRIPTION
## 问题

在 openclaw、Claude Code 等 Agent 平台中执行 skill 命令时，
平台在命令结束后会清理整个进程组（SIGTERM/SIGKILL），
导致通过 subprocess.Popen 启动的 Chrome 子进程随之退出。

表现为：每次调用 CLI 命令后 Chrome 自动关闭，
下一条命令不得不重新冷启动 Chrome，增加延迟且体验差。

## 修复

在 `launch_chrome()` 的 `subprocess.Popen` 中加入 `start_new_session=True`。

这会让 Chrome 成为新进程组的领导者，与 Python 父进程完全解耦。
父进程（或其所在进程组）被终止时，Chrome 不受影响，可持续在后台运行，
实现跨命令复用同一 Chrome 实例。

## 影响范围

仅影响 `launch_chrome()` 的启动行为，对 CDP 连接、端口复用逻辑无任何改动。