### PR TITLE
feat: 支持解析并返回评论中的图片

### DIFF
--- a/scripts/xhs/types.py
+++ b/scripts/xhs/types.py
@@ -190,6 +190,23 @@ class DetailImageInfo:
 
 
 @dataclass
+class CommentPicture:
+    width: int = 0
+    height: int = 0
+    url_default: str = ""
+    url_pre: str = ""
+
+    @classmethod
+    def from_dict(cls, d: dict) -> CommentPicture:
+        return cls(
+            width=d.get("width", 0),
+            height=d.get("height", 0),
+            url_default=d.get("urlDefault", ""),
+            url_pre=d.get("urlPre", ""),
+        )
+
+
+@dataclass
 class Comment:
     id: str = ""
     note_id: str = ""
@@ -202,6 +219,7 @@ class Comment:
     sub_comment_count: str = ""
     sub_comments: list[Comment] = field(default_factory=list)
     show_tags: list[str] = field(default_factory=list)
+    pictures: list[CommentPicture] = field(default_factory=list)
 
     @classmethod
     def from_dict(cls, d: dict) -> Comment:
@@ -217,6 +235,7 @@ class Comment:
             sub_comment_count=d.get("subCommentCount", ""),
             sub_comments=[cls.from_dict(c) for c in d.get("subComments", []) or []],
             show_tags=d.get("showTags", []) or [],
+            pictures=[CommentPicture.from_dict(p) for p in d.get("pictures", []) or []],
         )
 
     def to_dict(self) -> dict:
@@ -232,6 +251,11 @@ class Comment:
             },
             "subCommentCount": self.sub_comment_count,
         }
+        if self.pictures:
+            result["pictures"] = [
+                {"width": p.width, "height": p.height, "urlDefault": p.url_default}
+                for p in self.pictures
+            ]
         if self.sub_comments:
             result["subComments"] = [c.to_dict() for c in self.sub_comments]
         return result


### PR DESCRIPTION
## 问题

小红书评论支持发送图片，服务端在 __INITIAL_STATE__ 中通过
`pictures` 字段返回图片信息。但原有 `Comment` 类未声明该字段，
导致图片评论的 `content` 为空字符串，图片数据完全丢失。

受影响场景：晒穿搭、晒产品等以图片为主的评论，
在 get-feed-detail 返回结果中无法获取任何有效内容。

## 修复

- 新增 `CommentPicture` 数据类，包含 `width`、`height`、`urlDefault`、`urlPre`
- `Comment` 增加 `pictures: list[CommentPicture]` 字段
- `from_dict` 解析 `pictures` 数组（兼容空列表）
- `to_dict` 在存在图片时输出 `pictures`，仅含图片时 `content` 为空字符串属正常行为