### PR TITLE
fix: improve Linux Chrome editor detection

### DIFF
--- a/scripts/xhs/cdp.py
+++ b/scripts/xhs/cdp.py
@@ -248,25 +248,54 @@ class Page:
         )
 
     def input_content_editable(self, selector: str, text: str) -> None:
-        """向 contentEditable 元素输入文本（CDP 逐字输入，模拟真实打字）。"""
-        # 1. focus 元素
-        self.evaluate(
+        """向可编辑元素输入文本。"""
+        target = self.evaluate(
             f"""
             (() => {{
                 const el = document.querySelector({json.dumps(selector)});
-                if (el) el.focus();
+                if (!el) return null;
+                el.scrollIntoView({{block: 'center', inline: 'nearest'}});
+                const rect = el.getBoundingClientRect();
+                if (typeof el.focus === 'function') {{
+                    el.focus({{preventScroll: true}});
+                }}
+                if (el.isContentEditable) {{
+                    const selection = window.getSelection();
+                    const range = document.createRange();
+                    range.selectNodeContents(el);
+                    range.collapse(false);
+                    selection?.removeAllRanges();
+                    selection?.addRange(range);
+                }} else if (typeof el.setSelectionRange === 'function') {{
+                    const value = 'value' in el ? String(el.value || '') : '';
+                    el.setSelectionRange(value.length, value.length);
+                }}
+                return {{
+                    x: rect.left + rect.width / 2,
+                    y: rect.top + rect.height / 2,
+                    tagName: el.tagName,
+                    isTextControl: el.tagName === 'INPUT' || el.tagName === 'TEXTAREA',
+                }};
             }})()
             """
         )
+        if not target:
+            raise ElementNotFoundError(selector)
+
+        if target["x"] is not None and target["y"] is not None:
+            self.mouse_move(target["x"], target["y"])
+            time.sleep(random.uniform(0.03, 0.08))
+            self.mouse_click(target["x"], target["y"])
         time.sleep(0.1)
-        # 2. 全选清空（Ctrl+A + Backspace）
+
+        modifier = self.evaluate("navigator.platform.includes('Mac') ? 4 : 2") or 2
         self._send_session(
             "Input.dispatchKeyEvent",
-            {"type": "keyDown", "key": "a", "code": "KeyA", "modifiers": 2},
+            {"type": "keyDown", "key": "a", "code": "KeyA", "modifiers": modifier},
         )
         self._send_session(
             "Input.dispatchKeyEvent",
-            {"type": "keyUp", "key": "a", "code": "KeyA", "modifiers": 2},
+            {"type": "keyUp", "key": "a", "code": "KeyA", "modifiers": modifier},
         )
         self._send_session(
             "Input.dispatchKeyEvent",
@@ -287,19 +316,35 @@ class Page:
             },
         )
         time.sleep(0.1)
-        # 3. 逐字输入（随机 30-80ms 间隔，换行符转为 Enter 键）
-        for char in text:
-            if char == "\n":
+
+        if target["isTextControl"]:
+            self.evaluate(
+                f"""
+                (() => {{
+                    const el = document.querySelector({json.dumps(selector)});
+                    if (!el) return;
+                    const proto = el.tagName === 'TEXTAREA'
+                        ? window.HTMLTextAreaElement.prototype
+                        : window.HTMLInputElement.prototype;
+                    const setter = Object.getOwnPropertyDescriptor(proto, 'value')?.set;
+                    if (setter) {{
+                        setter.call(el, {json.dumps(text)});
+                    }} else {{
+                        el.value = {json.dumps(text)};
+                    }}
+                    el.dispatchEvent(new Event('input', {{bubbles: true}}));
+                    el.dispatchEvent(new Event('change', {{bubbles: true}}));
+                }})()
+                """
+            )
+            return
+
+        lines = text.split("\n")
+        for index, chunk in enumerate(lines):
+            if chunk:
+                self._send_session("Input.insertText", {"text": chunk})
+            if index < len(lines) - 1:
                 self.press_key("Enter")
-            else:
-                self._send_session(
-                    "Input.dispatchKeyEvent",
-                    {"type": "keyDown", "text": char},
-                )
-                self._send_session(
-                    "Input.dispatchKeyEvent",
-                    {"type": "keyUp", "text": char},
-                )
             time.sleep(random.uniform(0.03, 0.08))
 
     def get_element_text(self, selector: str) -> str | None:
@@ -450,6 +495,11 @@ class Page:
     def press_key(self, key: str) -> None:
         """按下并释放指定键。"""
         key_map = {
+            "Backspace": {
+                "key": "Backspace",
+                "code": "Backspace",
+                "windowsVirtualKeyCode": 8,
+            },
             "Enter": {"key": "Enter", "code": "Enter", "windowsVirtualKeyCode": 13},
             "ArrowDown": {
                 "key": "ArrowDown",

--- a/scripts/xhs/publish.py
+++ b/scripts/xhs/publish.py
@@ -36,6 +36,8 @@ from .urls import PUBLISH_URL
 
 logger = logging.getLogger(__name__)
 
+_EDITOR_MARKER_ATTR = "data-xhs-editor-target"
+
 
 def publish_image_content(page: Page, content: PublishImageContent) -> None:
     """发布图文内容（填写表单 + 点击发布）。
@@ -373,32 +375,135 @@ def _find_content_element(page: Page) -> str:
     if page.has_element(CONTENT_EDITOR):
         return CONTENT_EDITOR
 
-    # 查找带 placeholder 的 p 元素的 textbox 父元素
-    found = page.evaluate(
-        """
-        (() => {
-            const ps = document.querySelectorAll('p');
-            for (const p of ps) {
-                const placeholder = p.getAttribute('data-placeholder');
-                if (placeholder && placeholder.includes('输入正文描述')) {
-                    let current = p;
-                    for (let i = 0; i < 5; i++) {
-                        current = current.parentElement;
-                        if (!current) break;
-                        if (current.getAttribute('role') === 'textbox') {
-                            return 'found';
-                        }
-                    }
-                }
-            }
-            return '';
-        })()
-        """
+    selector = _find_best_editable_element(
+        page,
+        marker_value="content",
+        preferred_selectors=[
+            CONTENT_EDITOR,
+            "div.ProseMirror",
+            "[contenteditable='true'][role='textbox']",
+            "[contenteditable='plaintext-only'][role='textbox']",
+            "[role='textbox'][contenteditable]",
+            "div[contenteditable='true']",
+            "div[contenteditable='plaintext-only']",
+            "textarea[placeholder*='正文']",
+            "textarea[placeholder*='描述']",
+        ],
+        positive_keywords=["正文", "描述", "内容", "文章", "写下", "输入", "添加"],
+        negative_keywords=["标题", "搜索", "验证码", "手机号"],
     )
-    if found == "found":
-        return "[role='textbox']"
+    if selector:
+        return selector
 
     raise PublishError("没有找到内容输入框")
+
+
+def _find_best_editable_element(
+    page: Page,
+    *,
+    marker_value: str,
+    preferred_selectors: list[str],
+    positive_keywords: list[str],
+    negative_keywords: list[str] | None = None,
+) -> str:
+    """为动态页面定位最可能的可编辑输入区域。"""
+    selector = page.evaluate(
+        f"""
+        (() => {{
+            const markerAttr = {json.dumps(_EDITOR_MARKER_ATTR)};
+            const markerValue = {json.dumps(marker_value)};
+            const preferredSelectors = {json.dumps(preferred_selectors)};
+            const positiveKeywords = {json.dumps(positive_keywords)};
+            const negativeKeywords = {json.dumps(negative_keywords or [])};
+
+            const isVisible = (el) => {{
+                if (!el) return false;
+                const style = window.getComputedStyle(el);
+                if (style.display === 'none' || style.visibility === 'hidden') return false;
+                if (Number(style.opacity || '1') === 0) return false;
+                const rect = el.getBoundingClientRect();
+                if (rect.width < 8 || rect.height < 8) return false;
+                if (rect.bottom < 0 || rect.right < 0) return false;
+                return true;
+            }};
+
+            const isEditable = (el) => {{
+                if (!el) return false;
+                if (el.tagName === 'TEXTAREA' || el.tagName === 'INPUT') return true;
+                const role = el.getAttribute('role');
+                const ce = el.getAttribute('contenteditable');
+                return (
+                    el.isContentEditable
+                    || role === 'textbox'
+                    || ce === ''
+                    || ce === 'true'
+                    || ce === 'plaintext-only'
+                );
+            }};
+
+            const addCandidate = (list, seen, el, baseScore) => {{
+                if (!el || seen.has(el) || !isVisible(el) || !isEditable(el)) return;
+                seen.add(el);
+
+                const attrs = [
+                    el.getAttribute('placeholder') || '',
+                    el.getAttribute('data-placeholder') || '',
+                    el.getAttribute('aria-label') || '',
+                    el.getAttribute('aria-placeholder') || '',
+                    el.getAttribute('name') || '',
+                    el.className || '',
+                ];
+                const hint = attrs.join(' ').toLowerCase();
+                let score = baseScore;
+
+                for (const keyword of positiveKeywords) {{
+                    if (hint.includes(keyword.toLowerCase())) score += 24;
+                }}
+                for (const keyword of negativeKeywords) {{
+                    if (hint.includes(keyword.toLowerCase())) score -= 30;
+                }}
+
+                if (el.tagName === 'TEXTAREA') score += 10;
+                if (el.tagName === 'INPUT') score += 4;
+                if (el.isContentEditable) score += 12;
+                if ((el.getAttribute('role') || '') === 'textbox') score += 10;
+                if (hint.includes('ql-editor') || hint.includes('prosemirror')) score += 20;
+                if (hint.includes('editor')) score += 8;
+                if (attrs[0] || attrs[1] || attrs[2] || attrs[3]) score += 5;
+
+                const rect = el.getBoundingClientRect();
+                score += Math.min(rect.width * rect.height / 4000, 20);
+
+                list.push({{el, score}});
+            }};
+
+            document.querySelectorAll(`[${{markerAttr}}]`).forEach((node) => {{
+                node.removeAttribute(markerAttr);
+            }});
+
+            const candidates = [];
+            const seen = new Set();
+            preferredSelectors.forEach((sel, index) => {{
+                document.querySelectorAll(sel).forEach((el) => {{
+                    addCandidate(candidates, seen, el, 140 - index * 10);
+                }});
+            }});
+
+            document.querySelectorAll(
+                'div, section, article, textarea, input, [role="textbox"], [contenteditable]'
+            ).forEach((el) => {{
+                addCandidate(candidates, seen, el, 20);
+            }});
+
+            candidates.sort((a, b) => b.score - a.score);
+            const best = candidates[0]?.el;
+            if (!best) return '';
+            best.setAttribute(markerAttr, markerValue);
+            return `[${{markerAttr}}="${{markerValue}}"]`;
+        }})()
+        """
+    )
+    return selector if isinstance(selector, str) else ""
 
 
 def _check_title_max_length(page: Page) -> None:

--- a/scripts/xhs/publish_long_article.py
+++ b/scripts/xhs/publish_long_article.py
@@ -9,7 +9,12 @@ from pathlib import Path
 
 from .cdp import Page
 from .errors import PublishError
-from .publish import _click_publish_tab, _find_content_element, _navigate_to_publish_page
+from .publish import (
+    _click_publish_tab,
+    _find_best_editable_element,
+    _find_content_element,
+    _navigate_to_publish_page,
+)
 from .selectors import (
     AUTO_FORMAT_BUTTON_TEXT,
     CONTENT_EDITOR,
@@ -182,18 +187,31 @@ def _click_new_creation(page: Page) -> None:
 
 def _fill_long_title(page: Page, title: str) -> None:
     """填写长文标题（textarea，需使用 native setter）。"""
-    page.wait_for_element(LONG_ARTICLE_TITLE, timeout=10)
+    selector = _find_long_title_element(page)
 
     page.evaluate(
         f"""
         (() => {{
-            const el = document.querySelector({json.dumps(LONG_ARTICLE_TITLE)});
+            const el = document.querySelector({json.dumps(selector)});
             if (!el) return false;
-            const nativeSetter = Object.getOwnPropertyDescriptor(
-                window.HTMLTextAreaElement.prototype, 'value'
-            ).set;
-            el.focus();
-            nativeSetter.call(el, {json.dumps(title)});
+            el.scrollIntoView({{block: 'center', inline: 'nearest'}});
+            if (typeof el.focus === 'function') {{
+                el.focus({{preventScroll: true}});
+            }}
+
+            if (el.tagName === 'TEXTAREA' || el.tagName === 'INPUT') {{
+                const proto = el.tagName === 'TEXTAREA'
+                    ? window.HTMLTextAreaElement.prototype
+                    : window.HTMLInputElement.prototype;
+                const nativeSetter = Object.getOwnPropertyDescriptor(proto, 'value')?.set;
+                if (nativeSetter) {{
+                    nativeSetter.call(el, {json.dumps(title)});
+                }} else {{
+                    el.value = {json.dumps(title)};
+                }}
+            }} else {{
+                el.textContent = {json.dumps(title)};
+            }}
             el.dispatchEvent(new Event('input', {{ bubbles: true }}));
             el.dispatchEvent(new Event('change', {{ bubbles: true }}));
             return true;
@@ -202,6 +220,29 @@ def _fill_long_title(page: Page, title: str) -> None:
     )
     logger.info("已填写长文标题: %s", title[:20])
     time.sleep(0.5)
+
+
+def _find_long_title_element(page: Page) -> str:
+    """查找长文标题输入框。"""
+    if page.has_element(LONG_ARTICLE_TITLE):
+        return LONG_ARTICLE_TITLE
+
+    selector = _find_best_editable_element(
+        page,
+        marker_value="long-article-title",
+        preferred_selectors=[
+            LONG_ARTICLE_TITLE,
+            "textarea[placeholder*='标题']",
+            "input[placeholder*='标题']",
+            "textarea[aria-label*='标题']",
+            "input[aria-label*='标题']",
+        ],
+        positive_keywords=["标题", "题目", "文章标题"],
+        negative_keywords=["正文", "描述", "内容", "搜索"],
+    )
+    if selector:
+        return selector
+    raise PublishError("没有找到长文标题输入框")
 
 
 def _fill_long_content(page: Page, content: str) -> None:

--- a/tests/test_publish_selectors.py
+++ b/tests/test_publish_selectors.py
@@ -1,0 +1,60 @@
+"""发布页输入框定位相关单测。"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from xhs.errors import PublishError
+from xhs.publish import _find_content_element
+from xhs.publish_long_article import _find_long_title_element
+from xhs.selectors import CONTENT_EDITOR, LONG_ARTICLE_TITLE
+
+
+class FakePage:
+    """最小 Page 替身，仅覆盖输入框探测所需接口。"""
+
+    def __init__(self, *, existing: set[str] | None = None, evaluate_result: str = "") -> None:
+        self._existing = existing or set()
+        self._evaluate_result = evaluate_result
+
+    def has_element(self, selector: str) -> bool:
+        return selector in self._existing
+
+    def evaluate(self, _expression: str) -> str:
+        return self._evaluate_result
+
+
+def test_find_content_element_prefers_known_editor() -> None:
+    page = FakePage(existing={CONTENT_EDITOR})
+    assert _find_content_element(page) == CONTENT_EDITOR
+
+
+def test_find_content_element_uses_dynamic_fallback() -> None:
+    page = FakePage(evaluate_result='[data-xhs-editor-target="content"]')
+    assert _find_content_element(page) == '[data-xhs-editor-target="content"]'
+
+
+def test_find_content_element_raises_when_missing() -> None:
+    page = FakePage()
+    with pytest.raises(PublishError, match="内容输入框"):
+        _find_content_element(page)
+
+
+def test_find_long_title_element_prefers_known_selector() -> None:
+    page = FakePage(existing={LONG_ARTICLE_TITLE})
+    assert _find_long_title_element(page) == LONG_ARTICLE_TITLE
+
+
+def test_find_long_title_element_uses_dynamic_fallback() -> None:
+    page = FakePage(evaluate_result='[data-xhs-editor-target="long-article-title"]')
+    assert _find_long_title_element(page) == '[data-xhs-editor-target="long-article-title"]'
+
+
+def test_find_long_title_element_raises_when_missing() -> None:
+    page = FakePage()
+    with pytest.raises(PublishError, match="长文标题输入框"):
+        _find_long_title_element(page)


### PR DESCRIPTION
## 问题
Linux 环境下，图文和长文发布页输入框有时识别不到。

  ## 修复
  - 改进正文和长文标题输入框定位
  - 兼容 contenteditable、textarea、ProseMirror 等结构
  - 新增对应单测
