### PR TITLE
fix: 修复搜索筛选条件无法应用的问题

### DIFF
--- a/scripts/xhs/search.py
+++ b/scripts/xhs/search.py
@@ -132,8 +132,8 @@ def _wait_for_initial_state(page: Page, timeout: float = 10.0) -> None:
 
 def _apply_filters(page: Page, filters: list[tuple[int, int]]) -> None:
     """应用筛选条件。"""
-    # 悬停筛选按钮
-    page.hover_element(FILTER_BUTTON)
+    # 点击筛选按钮打开面板
+    page.click_element(FILTER_BUTTON)
 
     # 等待筛选面板出现
     deadline = time.monotonic() + 5.0


### PR DESCRIPTION
## 问题描述

使用 CLI 搜索命令的筛选参数时（如 `--note-type`、`--sort-by`、`--publish-time`），会报错：

```
Bridge 错误: 元素不存在: div.filter-panel div.filters:nth-child(2) div.tags:nth-child(3)
```

## 原因分析

`_apply_filters` 函数使用 `hover_element` 悬停筛选按钮来打开筛选面板，但小红书页面需要**点击**才能展开筛选选项。

## 修复内容

**scripts/xhs/search.py:136**

```diff
- page.hover_element(FILTER_BUTTON)
+ page.click_element(FILTER_BUTTON)
```

## 测试验证

```bash
# 单条件筛选 ✅
python scripts/cli.py search-feeds --keyword "Python编程" --note-type "图文"

# 多条件筛选 ✅
python scripts/cli.py search-feeds --keyword "Python" \
  --sort-by "最多点赞" --note-type "图文" --publish-time "一周内"
```

所有筛选条件（排序、类型、时间、范围、位置）现在都能正常工作。

## 变更文件

- `scripts/xhs/search.py` - 1 行修改