### PR TITLE
feat: add share URL support to search-feeds and new get-share-url command

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -81,8 +81,9 @@ metadata:
 | 命令 | 功能 |
 |------|------|
 | `cli.py list-feeds` | 获取首页推荐 Feed |
-| `cli.py search-feeds` | 关键词搜索笔记 |
+| `cli.py search-feeds` | 关键词搜索笔记（返回含 shareUrl） |
 | `cli.py get-feed-detail` | 获取笔记完整内容和评论 |
+| `cli.py get-share-url` | 根据 feed-id + xsec-token 生成可分享链接 |
 | `cli.py user-profile` | 获取用户主页信息 |
 
 ### xhs-interact — 社交互动
@@ -119,19 +120,23 @@ python scripts/cli.py search-feeds --keyword "关键词"
 python scripts/cli.py get-feed-detail \
   --feed-id FEED_ID --xsec-token XSEC_TOKEN
 
-# 6. 发布图文
+# 6. 获取可分享链接
+python scripts/cli.py get-share-url \
+  --feed-id FEED_ID --xsec-token XSEC_TOKEN
+
+# 7. 发布图文
 python scripts/cli.py publish \
   --title-file title.txt \
   --content-file content.txt \
   --images "/abs/path/pic1.jpg"
 
-# 7. 发表评论
+# 8. 发表评论
 python scripts/cli.py post-comment \
   --feed-id FEED_ID \
   --xsec-token XSEC_TOKEN \
   --content "评论内容"
 
-# 8. 点赞
+# 9. 点赞
 python scripts/cli.py like-feed \
   --feed-id FEED_ID --xsec-token XSEC_TOKEN
 ```

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -659,6 +659,12 @@ def cmd_get_feed_detail(args: argparse.Namespace) -> None:
         browser.close()
 
 
+def cmd_get_share_url(args: argparse.Namespace) -> None:
+    """根据 feed-id 和 xsec-token 生成可分享链接。"""
+    url = f"https://www.xiaohongshu.com/explore/{args.feed_id}?xsec_token={args.xsec_token}&xsec_source=pc_search"
+    _output({"feedId": args.feed_id, "shareUrl": url})
+
+
 def cmd_user_profile(args: argparse.Namespace) -> None:
     """获取用户主页。"""
     from xhs.user_profile import get_user_profile
@@ -1116,6 +1122,12 @@ def build_parser() -> argparse.ArgumentParser:
     sub.add_argument("--max-comment-items", type=int, default=0, help="最大评论数 (0=不限)")
     sub.add_argument("--scroll-speed", default="normal", help="滚动速度: slow|normal|fast")
     sub.set_defaults(func=cmd_get_feed_detail)
+
+    # get-share-url
+    sub = subparsers.add_parser("get-share-url", help="生成笔记的可分享链接")
+    sub.add_argument("--feed-id", required=True, help="Feed ID")
+    sub.add_argument("--xsec-token", required=True, help="xsec_token")
+    sub.set_defaults(func=cmd_get_share_url)
 
     # user-profile
     sub = subparsers.add_parser("user-profile", help="获取用户主页")

--- a/scripts/xhs/types.py
+++ b/scripts/xhs/types.py
@@ -139,11 +139,19 @@ class Feed:
             index=d.get("index", 0),
         )
 
+    @property
+    def share_url(self) -> str:
+        """生成可分享的小红书链接。"""
+        if self.id and self.xsec_token:
+            return f"https://www.xiaohongshu.com/explore/{self.id}?xsec_token={self.xsec_token}&xsec_source=pc_search"
+        return ""
+
     def to_dict(self) -> dict:
         """序列化为 JSON 兼容的字典。"""
         result: dict = {
             "id": self.id,
             "xsecToken": self.xsec_token,
+            "shareUrl": self.share_url,
             "modelType": self.model_type,
             "index": self.index,
             "displayTitle": self.note_card.display_title,


### PR DESCRIPTION
## What

Add share URL generation capability so agents can produce clickable Xiaohongshu links.

### Changes

1. **`search-feeds` output now includes `shareUrl`** — each feed result has a ready-to-use share link
2. **New `get-share-url` command** — generate a share link from feed-id + xsec-token
3. **SKILL.md updated** with new command docs

### Share URL format

```
https://www.xiaohongshu.com/explore/<id>?xsec_token=<token>&xsec_source=pc_search
```

### Why

Previously, getting a shareable Xiaohongshu link required:
- Logging in to the web UI and clicking the share button, OR
- Manually concatenating the URL from search results

Now it's built into the CLI output automatically.

### Usage

```bash
# Search already includes shareUrl per result
python scripts/cli.py search-feeds --keyword "保定一日游"
# → each feed has "shareUrl": "https://..."

# Or generate a link directly
python scripts/cli.py get-share-url --feed-id XXX --xsec-token YYY
```

### Files changed
- `scripts/xhs/types.py` — Feed.share_url property + shareUrl in to_dict()
- `scripts/cli.py` — cmd_get_share_url + subparser registration
- `SKILL.md` — documentation update
