### PR TITLE
fix: 硬编码 sleep → sleep_random 降低机械节奏风控风险

### DIFF
--- a/scripts/xhs/feeds.py
+++ b/scripts/xhs/feeds.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 import json
 import logging
-import time
 
 from .cdp import Page
 from .errors import NoFeedsError
+from .human import sleep_random
 from .types import Feed
 from .urls import HOME_URL
 
@@ -39,7 +39,7 @@ def list_feeds(page: Page) -> list[Feed]:
     page.navigate(HOME_URL)
     page.wait_for_load()
     page.wait_dom_stable()
-    time.sleep(1)
+    sleep_random(800, 1600)
 
     result = page.evaluate(_EXTRACT_FEEDS_JS)
     if not result:

--- a/scripts/xhs/like_favorite.py
+++ b/scripts/xhs/like_favorite.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 import json
 import logging
-import time
 
 from .cdp import Page
 from .errors import NoFeedDetailError
+from .human import sleep_random
 from .selectors import COLLECT_BUTTON, LIKE_BUTTON
 from .types import ActionResult
 from .urls import make_feed_detail_url
@@ -55,7 +55,7 @@ def _prepare_page(page: Page, feed_id: str, xsec_token: str) -> None:
     page.navigate(url)
     page.wait_for_load()
     page.wait_dom_stable()
-    time.sleep(1)
+    sleep_random(1500, 3500)
 
 
 # ========== 点赞 ==========
@@ -90,7 +90,7 @@ def _toggle_like(page: Page, feed_id: str, target_liked: bool) -> ActionResult:
 
     # 点击
     page.click_element(LIKE_BUTTON)
-    time.sleep(3)
+    sleep_random(1500, 3500)
 
     # 验证
     try:
@@ -104,7 +104,7 @@ def _toggle_like(page: Page, feed_id: str, target_liked: bool) -> ActionResult:
     # 重试一次
     logger.warning("feed %s %s可能未成功，重试", feed_id, action_name)
     page.click_element(LIKE_BUTTON)
-    time.sleep(2)
+    sleep_random(900, 1800)
 
     return ActionResult(feed_id=feed_id, success=True, message=f"{action_name}已执行")
 
@@ -141,7 +141,7 @@ def _toggle_favorite(page: Page, feed_id: str, target_collected: bool) -> Action
 
     # 点击
     page.click_element(COLLECT_BUTTON)
-    time.sleep(3)
+    sleep_random(1500, 3500)
 
     # 验证
     try:
@@ -155,6 +155,6 @@ def _toggle_favorite(page: Page, feed_id: str, target_collected: bool) -> Action
     # 重试
     logger.warning("feed %s %s可能未成功，重试", feed_id, action_name)
     page.click_element(COLLECT_BUTTON)
-    time.sleep(2)
+    sleep_random(900, 1800)
 
     return ActionResult(feed_id=feed_id, success=True, message=f"{action_name}已执行")

--- a/scripts/xhs/publish.py
+++ b/scripts/xhs/publish.py
@@ -10,6 +10,7 @@ import time
 
 from .cdp import Page
 from .errors import ContentTooLongError, PublishError, TitleTooLongError, UploadTimeoutError
+from .human import sleep_random
 from .selectors import (
     CONTENT_EDITOR,
     CONTENT_LENGTH_ERROR,
@@ -135,7 +136,7 @@ def click_publish_button(page: Page) -> None:
     )
     if not clicked:
         raise PublishError("未找到发布按钮")
-    time.sleep(3)
+    sleep_random(2500, 4500)
     logger.info("发布完成")
 
 
@@ -156,7 +157,7 @@ def save_as_draft(page: Page) -> None:
         """
     )
     if clicked:
-        time.sleep(2)
+        sleep_random(1500, 2800)
         logger.info("已点击「暂存离开」，内容已保存到草稿箱")
     else:
         logger.warning("未找到「暂存离开」按钮")
@@ -170,9 +171,9 @@ def _navigate_to_publish_page(page: Page) -> None:
     """导航到发布页面。"""
     page.navigate(PUBLISH_URL)
     page.wait_for_load(timeout=300)
-    time.sleep(3)
+    sleep_random(2500, 4000)
     page.wait_dom_stable()
-    time.sleep(2)
+    sleep_random(1500, 2800)
 
 
 def _click_publish_tab(page: Page, tab_name: str) -> None:

--- a/scripts/xhs/publish_video.py
+++ b/scripts/xhs/publish_video.py
@@ -8,6 +8,7 @@ import time
 
 from .cdp import Page
 from .errors import PublishError, UploadTimeoutError
+from .human import sleep_random
 from .publish import (
     _click_publish_tab,
     _find_content_element,
@@ -61,7 +62,7 @@ def fill_publish_video_form(page: Page, content: PublishVideoContent) -> None:
 
     # 点击"上传视频" TAB
     _click_publish_tab(page, "上传视频")
-    time.sleep(1)
+    sleep_random(800, 1500)
 
     # 上传视频
     _upload_video(page, content.video_path)
@@ -85,7 +86,7 @@ def click_publish_video_button(page: Page) -> None:
     """
     _wait_for_publish_button_clickable(page)
     page.click_element(PUBLISH_BUTTON)
-    time.sleep(3)
+    sleep_random(2500, 4500)
     logger.info("视频发布完成")
 
 
@@ -142,19 +143,19 @@ def _fill_publish_video_form(
     """填写视频表单（不点击发布）。"""
     # 标题
     page.input_text(TITLE_INPUT, title)
-    time.sleep(1)
+    sleep_random(800, 1500)
 
     # 正文 + 标签
     content_selector = _find_content_element(page)
     page.input_content_editable(content_selector, content)
 
     # 回点标题
-    time.sleep(1)
+    sleep_random(600, 1200)
     page.click_element(TITLE_INPUT)
 
     if tags:
         _input_tags(page, content_selector, tags)
-    time.sleep(1)
+    sleep_random(600, 1400)
 
     # 定时发布
     if schedule_time:


### PR DESCRIPTION
## Summary
- 将 `like_favorite` / `feeds` / `publish` / `publish_video` 中关键写/导航路径上的固定 `time.sleep` 替换为 `sleep_random`，避免机械节奏被识别为自动化。
- 仅替换"动作间隔"类等待，**不动**轮询循环内的 sleep（如 `_wait_for_publish_button_clickable`）和 `≤1s` 的表单/弹窗微等待。

## Changes
| 文件 | 处数 | 说明 |
|------|------|------|
| `scripts/xhs/like_favorite.py` | 5 | 导航 + 点赞/收藏/重试，移除 `import time` |
| `scripts/xhs/feeds.py` | 1 | 首页加载后，移除 `import time` |
| `scripts/xhs/publish.py` | 4 | 导航 / 点击发布 / 存草稿，保留 `import time` |
| `scripts/xhs/publish_video.py` | 5 | tab / 发布按钮 / 表单填写，保留 `import time`（轮询和 monotonic 仍需） |

## Test plan
- [x] `uv run ruff check` 改动文件全部通过
- [x] `uv run pytest`（仓库目前无 test case）
- [ ] 手动冒烟：`like-feed` / `favorite-feed` / `publish` 节奏变慢但流程正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)