### PR TITLE
fix(favorite): fix favorite and unfavorite actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,7 +173,7 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
 
 # Abstra
 # Abstra is an AI-powered process automation framework.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 license = { text = "MIT" }
 requires-python = ">=3.11"
 dependencies = [
+    "python-socks>=2.8.1",
     "requests>=2.28.0",
     "websockets>=12.0",
 ]

--- a/scripts/xhs/bridge.py
+++ b/scripts/xhs/bridge.py
@@ -55,10 +55,13 @@ class BridgePage:
         self._call("wait_for_load", {"timeout": int(timeout * 1000)})
 
     def wait_dom_stable(self, timeout: float = 10.0, interval: float = 0.5) -> None:
-        self._call("wait_dom_stable", {
-            "timeout": int(timeout * 1000),
-            "interval": int(interval * 1000),
-        })
+        self._call(
+            "wait_dom_stable",
+            {
+                "timeout": int(timeout * 1000),
+                "interval": int(interval * 1000),
+            },
+        )
 
     # ─── JavaScript 执行 ────────────────────────────────────────
 
@@ -83,10 +86,13 @@ class BridgePage:
         return bool(self._call("has_element", {"selector": selector}))
 
     def wait_for_element(self, selector: str, timeout: float = 30.0) -> str:
-        found = self._call("wait_for_selector", {
-            "selector": selector,
-            "timeout": int(timeout * 1000),
-        })
+        found = self._call(
+            "wait_for_selector",
+            {
+                "selector": selector,
+                "timeout": int(timeout * 1000),
+            },
+        )
         if not found:
             raise ElementNotFoundError(selector)
         return "found"
@@ -94,7 +100,46 @@ class BridgePage:
     # ─── 元素操作 ────────────────────────────────────────────────
 
     def click_element(self, selector: str) -> None:
-        self._call("click_element", {"selector": selector})
+        self.evaluate(
+            f"""
+            (() => {{
+                const nodes = Array.from(document.querySelectorAll({json.dumps(selector)}));
+                if (!nodes.length) throw new Error('元素不存在: ' + {json.dumps(selector)});
+                const visible = nodes.find((el) => {{
+                    const rect = el.getBoundingClientRect();
+                    if (rect.width <= 0 || rect.height <= 0) return false;
+                    const style = window.getComputedStyle(el);
+                    return style.display !== 'none' && style.visibility !== 'hidden';
+                }}) || nodes[0];
+                const target = visible.closest("button,[role='button'],a,[tabindex]") || visible;
+                target.scrollIntoView({{block: 'center'}});
+                if (typeof target.focus === 'function') target.focus();
+
+                if (typeof target.click === 'function') {{
+                    target.click();
+                    return;
+                }}
+
+                const rect = target.getBoundingClientRect();
+                const x = rect.left + rect.width / 2;
+                const y = rect.top + rect.height / 2;
+                const pointEl = document.elementFromPoint(x, y);
+                const dispatchTarget =
+                    pointEl && (pointEl === target || target.contains(pointEl))
+                        ? pointEl
+                        : target;
+
+                ['pointerdown', 'mousedown', 'pointerup', 'mouseup', 'click'].forEach((t) => {{
+                    dispatchTarget.dispatchEvent(new MouseEvent(t, {{
+                        bubbles: true,
+                        cancelable: true,
+                        clientX: x,
+                        clientY: y,
+                    }}));
+                }});
+            }})()
+            """
+        )
 
     def input_text(self, selector: str, text: str) -> None:
         self._call("input_text", {"selector": selector, "text": text})

--- a/scripts/xhs/cdp.py
+++ b/scripts/xhs/cdp.py
@@ -215,10 +215,17 @@ class Page:
         box = self.evaluate(
             f"""
             (() => {{
-                const el = document.querySelector({json.dumps(selector)});
-                if (!el) return null;
-                el.scrollIntoView({{block: 'center'}});
-                const rect = el.getBoundingClientRect();
+                const nodes = Array.from(document.querySelectorAll({json.dumps(selector)}));
+                if (!nodes.length) return null;
+                const visible = nodes.find((el) => {{
+                    const rect = el.getBoundingClientRect();
+                    if (rect.width <= 0 || rect.height <= 0) return false;
+                    const style = window.getComputedStyle(el);
+                    return style.display !== 'none' && style.visibility !== 'hidden';
+                }}) || nodes[0];
+                const target = visible.closest("button,[role='button'],a,[tabindex]") || visible;
+                target.scrollIntoView({{block: 'center'}});
+                const rect = target.getBoundingClientRect();
                 return {{x: rect.left + rect.width / 2, y: rect.top + rect.height / 2}};
             }})()
             """
@@ -527,7 +534,9 @@ class Page:
         try:
             doc = self._send_session("DOM.getDocument", {"depth": 0})
             root_id = doc["root"]["nodeId"]
-            query = self._send_session("DOM.querySelector", {"nodeId": root_id, "selector": selector})
+            query = self._send_session(
+                "DOM.querySelector", {"nodeId": root_id, "selector": selector}
+            )
             node_id = query.get("nodeId", 0)
             if not node_id:
                 return b""

--- a/scripts/xhs/like_favorite.py
+++ b/scripts/xhs/like_favorite.py
@@ -42,6 +42,9 @@ def _get_interact_state(page: Page, feed_id: str) -> tuple[bool, bool]:
 
     note_detail_map = json.loads(result)
     detail = note_detail_map.get(feed_id)
+    if not detail and len(note_detail_map) == 1:
+        detail = next(iter(note_detail_map.values()))
+
     if not detail:
         raise NoFeedDetailError()
 
@@ -124,6 +127,36 @@ def unfavorite_feed(page: Page, feed_id: str, xsec_token: str) -> ActionResult:
     return _toggle_favorite(page, feed_id, target_collected=False)
 
 
+def _wait_collect_button(page: Page, timeout: float = 5.0, interval: float = 0.2) -> bool:
+    """等待收藏按钮出现。"""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if page.has_element(COLLECT_BUTTON):
+            return True
+        time.sleep(interval)
+    return False
+
+
+def _wait_collected_state(
+    page: Page,
+    feed_id: str,
+    target_collected: bool,
+    timeout: float = 3.0,
+    interval: float = 0.3,
+) -> bool:
+    """短轮询验证收藏状态是否达到目标。"""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            _, collected = _get_interact_state(page, feed_id)
+            if collected == target_collected:
+                return True
+        except NoFeedDetailError:
+            pass
+        time.sleep(interval)
+    return False
+
+
 def _toggle_favorite(page: Page, feed_id: str, target_collected: bool) -> ActionResult:
     """执行收藏/取消收藏操作。"""
     action_name = "收藏" if target_collected else "取消收藏"
@@ -139,22 +172,25 @@ def _toggle_favorite(page: Page, feed_id: str, target_collected: bool) -> Action
         logger.info("feed %s 已%s，跳过", feed_id, action_name)
         return ActionResult(feed_id=feed_id, success=True, message=f"已{action_name}")
 
-    # 点击
-    page.click_element(COLLECT_BUTTON)
-    time.sleep(3)
+    if not _wait_collect_button(page, timeout=5.0):
+        logger.error("feed %s 未找到收藏按钮: %s", feed_id, COLLECT_BUTTON)
+        return ActionResult(
+            feed_id=feed_id, success=False, message=f"{action_name}失败：未找到收藏按钮"
+        )
 
-    # 验证
-    try:
-        _, collected = _get_interact_state(page, feed_id)
-        if collected == target_collected:
+    for attempt in range(2):
+        if attempt > 0:
+            logger.warning("feed %s %s首次未确认成功，重试", feed_id, action_name)
+
+        try:
+            page.click_element(COLLECT_BUTTON)
+        except Exception as e:
+            logger.warning("feed %s 点击收藏按钮失败（第%d次）: %s", feed_id, attempt + 1, e)
+            continue
+
+        if _wait_collected_state(page, feed_id, target_collected, timeout=3.0, interval=0.3):
             logger.info("feed %s %s成功", feed_id, action_name)
             return ActionResult(feed_id=feed_id, success=True, message=f"{action_name}成功")
-    except NoFeedDetailError:
-        pass
 
-    # 重试
-    logger.warning("feed %s %s可能未成功，重试", feed_id, action_name)
-    page.click_element(COLLECT_BUTTON)
-    time.sleep(2)
-
-    return ActionResult(feed_id=feed_id, success=True, message=f"{action_name}已执行")
+    logger.error("feed %s %s未确认成功", feed_id, action_name)
+    return ActionResult(feed_id=feed_id, success=False, message=f"{action_name}失败：状态未变化")

--- a/uv.lock
+++ b/uv.lock
@@ -155,6 +155,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-socks"
+version = "2.8.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/0b/cd77011c1bc01b76404f7aba07fca18aca02a19c7626e329b40201217624/python_socks-2.8.1.tar.gz", hash = "sha256:698daa9616d46dddaffe65b87db222f2902177a2d2b2c0b9a9361df607ab3687", size = 38909, upload-time = "2026-02-16T05:24:00.745Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/fe/9a58cb6eec633ff6afae150ca53c16f8cc8b65862ccb3d088051efdfceb7/python_socks-2.8.1-py3-none-any.whl", hash = "sha256:28232739c4988064e725cdbcd15be194743dd23f1c910f784163365b9d7be035", size = 55087, upload-time = "2026-02-16T05:23:59.147Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.32.5"
 source = { registry = "https://pypi.org/simple" }
@@ -267,6 +276,7 @@ name = "xiaohongshu-skills"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "python-socks" },
     { name = "requests" },
     { name = "websockets" },
 ]
@@ -285,6 +295,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
+    { name = "python-socks", specifier = ">=2.8.1" },
     { name = "requests", specifier = ">=2.28.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.9.0" },
     { name = "websockets", specifier = ">=12.0" },


### PR DESCRIPTION
## Summary
- Fix broken `favorite-feed` and `favorite-feed --unfavorite` actions.
- Update low-level `Page.click_element` handling (Bridge + CDP) so favorite-related click targets are correctly triggered.
- Add missing runtime dependency: `python-socks`.

## Changes
- `scripts/xhs/like_favorite.py`
  - Fix favorite/unfavorite action flow.
  - Add proper wait + state-check + retry path for action confirmation.
- `scripts/xhs/bridge.py`
  - Improve click target resolution for Bridge page interactions.
- `scripts/xhs/cdp.py`
  - Improve click target resolution for CDP page interactions.
- `pyproject.toml`, `uv.lock`
  - Add `python-socks` dependency.
- `.gitignore`
  - Ignore `.idea/`.

## Validation
- Direct fix verification:
  - `favorite-feed` (favorite): pass
  - `favorite-feed --unfavorite` (unfavorite): pass
- Additional regression verification (because `Page.click_element` was changed):
  - `like-feed` (like): pass
  - `like-feed --unlike` (unlike): pass
- Local check:
  - `uv run python -m py_compile scripts/xhs/bridge.py scripts/xhs/cdp.py scripts/xhs/like_favorite.py`

## Risk & Rollback
- Risk scope: click handling and interaction action paths.
- Rollback plan: revert the 3 commits in this PR if regressions are found.