### PR TITLE
feat: add rednote.com domain support + text-based filter selectors

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -517,15 +517,17 @@ function domExecutor(method, params) {
 // ───────────────────────── Tab 管理 ─────────────────────────
 
 async function getOrOpenXhsTab() {
-  const tabs = await chrome.tabs.query({
-    url: [
-      "https://www.xiaohongshu.com/*",
-      "https://xiaohongshu.com/*",
-      "https://creator.xiaohongshu.com/*",
-    ],
-  });
+  const xhsUrls = [
+    "https://www.xiaohongshu.com/*",
+    "https://xiaohongshu.com/*",
+    "https://creator.xiaohongshu.com/*",
+    "https://www.rednote.com/*",
+    "https://rednote.com/*",
+    "https://creator.rednote.com/*",
+  ];
+  const tabs = await chrome.tabs.query({ url: xhsUrls });
   if (tabs.length > 0) return tabs[0];
-  // 没有已打开的 XHS 页面，新建一个
+  // 没有已打开的 XHS/RedNote 页面，新建一个
   const tab = await chrome.tabs.create({ url: "https://www.xiaohongshu.com/" });
   await waitForTabComplete(tab.id, null, 30000);
   return tab;

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -14,6 +14,9 @@
     "https://www.xiaohongshu.com/*",
     "https://xiaohongshu.com/*",
     "https://creator.xiaohongshu.com/*",
+    "https://www.rednote.com/*",
+    "https://rednote.com/*",
+    "https://creator.rednote.com/*",
     "ws://localhost/*"
   ],
   "background": {
@@ -24,7 +27,10 @@
       "matches": [
         "https://www.xiaohongshu.com/*",
         "https://xiaohongshu.com/*",
-        "https://creator.xiaohongshu.com/*"
+        "https://creator.xiaohongshu.com/*",
+        "https://www.rednote.com/*",
+        "https://rednote.com/*",
+        "https://creator.rednote.com/*"
       ],
       "js": ["content.js"],
       "run_at": "document_idle"

--- a/scripts/xhs/login.py
+++ b/scripts/xhs/login.py
@@ -30,7 +30,7 @@ from .selectors import (
     USER_NICKNAME,
     USER_PROFILE_NAV_LINK,
 )
-from .urls import EXPLORE_URL
+from .urls import EXPLORE_URL, _BASE
 
 logger = logging.getLogger(__name__)
 
@@ -69,7 +69,7 @@ def get_current_user_nickname(page: Page) -> str:
             return ""
 
         # 导航到个人主页读取真实昵称
-        profile_url = f"https://www.xiaohongshu.com{profile_href}"
+        profile_url = f"https://www.{_BASE}{profile_href}"
         page.navigate(profile_url)
         page.wait_for_load()
         page.wait_dom_stable()

--- a/scripts/xhs/search.py
+++ b/scripts/xhs/search.py
@@ -131,8 +131,8 @@ def _wait_for_initial_state(page: Page, timeout: float = 10.0) -> None:
 
 
 def _apply_filters(page: Page, filters: list[tuple[int, int]]) -> None:
-    """应用筛选条件。"""
-    # 悬停筛选按钮
+    """应用筛选条件（使用文本匹配，兼容 rednote.com DOM 差异）。"""
+    # 悬停筛选按钮打开面板
     page.hover_element(FILTER_BUTTON)
 
     # 等待筛选面板出现
@@ -142,13 +142,58 @@ def _apply_filters(page: Page, filters: list[tuple[int, int]]) -> None:
             break
         sleep_random(300, 600)
 
-    # 点击各筛选项
+    # 点击各筛选项（通过文本内容匹配，而非 nth-child 索引）
     for filters_index, tags_index in filters:
-        selector = (
-            f"div.filter-panel div.filters:nth-child({filters_index}) "
-            f"div.tags:nth-child({tags_index})"
+        options = _FILTER_OPTIONS.get(filters_index)
+        if not options:
+            continue
+        # 从映射表查找对应文本标签
+        option_text = None
+        for ti, text in options:
+            if ti == tags_index:
+                option_text = text
+                break
+        if not option_text:
+            continue
+
+        # JS 在筛选面板中查找包含指定文本的标签元素
+        box = page.evaluate(
+            f"""
+            (() => {{
+                const panel = document.querySelector({json.dumps(FILTER_PANEL)});
+                if (!panel) return null;
+                // 兼容多种 DOM 结构：div.filters / div.filter-group / [class*=filter]
+                const groups = panel.querySelectorAll(
+                    'div.filters, div.filter-group, [class*="filter-group"]'
+                );
+                const gi = {filters_index} - 1;
+                if (gi < 0 || gi >= groups.length) return null;
+                const group = groups[gi];
+                // 兼容多种标签元素
+                const tags = group.querySelectorAll(
+                    'div.tag, div.tags, span.tag, span.tags, [class*="tag"]'
+                );
+                for (const tag of tags) {{
+                    const t = (tag.textContent || '').trim();
+                    if (t === {json.dumps(option_text)}) {{
+                        tag.scrollIntoView({{block: 'center'}});
+                        const r = tag.getBoundingClientRect();
+                        return {{x: r.left + r.width / 2, y: r.top + r.height / 2}};
+                    }}
+                }}
+                return null;
+            }})()
+            """
         )
-        page.click_element(selector)
+        if not box:
+            logger.warning("未找到筛选项: 组%d 标签'%s'", filters_index, option_text)
+            continue
+
+        x = box["x"] + random.uniform(-3, 3)
+        y = box["y"] + random.uniform(-3, 3)
+        page.mouse_move(x, y)
+        time.sleep(random.uniform(0.03, 0.08))
+        page.mouse_click(x, y)
         sleep_random(300, 600)
 
     # 等待页面更新

--- a/scripts/xhs/urls.py
+++ b/scripts/xhs/urls.py
@@ -1,29 +1,35 @@
 """小红书 URL 常量和构建函数。"""
 
+import os
 from urllib.parse import urlencode
 
+# XHS_BASE_DOMAIN 支持 rednote.com（国际版）和 xiaohongshu.com（中国版）
+# 默认 xiaohongshu.com；国际用户设置 XHS_BASE_DOMAIN=rednote.com
+_BASE = os.environ.get("XHS_BASE_DOMAIN", "xiaohongshu.com")
+
 # 基础页面
-EXPLORE_URL = "https://www.xiaohongshu.com/explore"
-HOME_URL = "https://www.xiaohongshu.com"
-PUBLISH_URL = "https://creator.xiaohongshu.com/publish/publish?source=official"
+EXPLORE_URL = f"https://www.{_BASE}/explore"
+HOME_URL = f"https://www.{_BASE}"
+PUBLISH_URL = f"https://creator.{_BASE}/publish/publish?source=official"
 
 
 def make_feed_detail_url(feed_id: str, xsec_token: str) -> str:
     """构建 feed 详情页 URL。"""
     return (
-        f"https://www.xiaohongshu.com/explore/{feed_id}?xsec_token={xsec_token}&xsec_source=pc_feed"
+        f"https://www.{_BASE}/explore/{feed_id}"
+        f"?xsec_token={xsec_token}&xsec_source=pc_feed"
     )
 
 
 def make_search_url(keyword: str) -> str:
     """构建搜索结果页 URL。"""
     params = urlencode({"keyword": keyword, "source": "web_explore_feed"})
-    return f"https://www.xiaohongshu.com/search_result?{params}"
+    return f"https://www.{_BASE}/search_result?{params}"
 
 
 def make_user_profile_url(user_id: str, xsec_token: str) -> str:
     """构建用户主页 URL。"""
     return (
-        f"https://www.xiaohongshu.com/user/profile/{user_id}"
+        f"https://www.{_BASE}/user/profile/{user_id}"
         f"?xsec_token={xsec_token}&xsec_source=pc_note"
     )


### PR DESCRIPTION
## Summary

This PR adds support for `rednote.com` (the international domain for Xiaohongshu/小红书) and fixes the filter selector to work across both domains.

## Changes

### 1. Domain Configuration (`scripts/xhs/urls.py`)
- Added `XHS_BASE_DOMAIN` environment variable (defaults to `xiaohongshu.com`)
- All URL construction now uses the dynamic base domain
- Usage: `XHS_BASE_DOMAIN=rednote.com python scripts/cli.py <command>`

### 2. Filter Selector Fix (`scripts/xhs/search.py`)
- Replaced `nth-child` CSS selectors in `_apply_filters()` with text-based element matching
- The old approach assumed identical DOM structure on both domains, which failed on rednote.com
- New approach uses JavaScript to find filter tags by their text content (e.g. "最新", "视频")
- Compatible with multiple DOM structures (div.filters, div.filter-group, etc.)

### 3. Chrome Extension Support (`extension/`)
- Added `rednote.com` and `creator.rednote.com` to host permissions in `manifest.json`
- Added rednote.com URLs to `getOrOpenXhsTab()` tab matching in `background.js`
- Content scripts now inject on rednote.com pages

### 4. Login Fix (`scripts/xhs/login.py`)
- Updated hardcoded `www.xiaohongshu.com` to use dynamic `_BASE` domain

## Backward Compatibility
- Default behavior unchanged — `xiaohongshu.com` remains the default
- No breaking changes for existing users
- International users can opt-in via `XHS_BASE_DOMAIN=rednote.com`