### PR TITLE
feat: XHS NetLogger 反爬监控体系 + CLI 风控接口 (isRiskUser 实时判定)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,3 +75,5 @@ python scripts/cli.py publish --title-file t.txt --content-file c.txt --images p
 | `long-article` | — | 长文发布（填写+排版） |
 | `select-template` | — | 长文发布（选择模板） |
 | `next-step` | — | 长文发布（下一步+描述） |
+| `get-netlog` | — | 风控数据 |
+| `risk-report` | — | 风控数据 |

--- a/docs/superpowers/plans/2026-05-19-xhs-netlogger.md
+++ b/docs/superpowers/plans/2026-05-19-xhs-netlogger.md
@@ -1,0 +1,1346 @@
+# XHS NetLogger Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **Note on testing:** Per the spec (`docs/superpowers/specs/2026-05-19-xhs-netlogger-design.md`), this feature does NOT have automated tests — browser extension + live XHS domain cannot be reproduced offline. Each task uses manual smoke-verification steps instead of TDD. Run each verification BEFORE marking step complete.
+
+**Goal:** 给小红书 Chrome 扩展加 netlogger 能力（彩蛋激活），抓取 webRequest 全量 + fetch/XHR 响应体，分类展示用于反推 XHS 检测维度。
+
+**Architecture:** 方案 B —— `chrome.webRequest` 4 阶段监听拿外层 HTTP 信号（含跨域风控上报域请求体），`interceptor.js` MAIN world hook fetch/XHR 拿业务域响应体；两者按 `(method, url, 2s 时间窗)` 关联合并；存 `chrome.storage.local`；popup 内"NetLog"卡片（标题连点 5 次激活）展示时序流 + 检测维度归类双 tab。
+
+**Tech Stack:** Chrome Extension MV3、`chrome.webRequest`/`chrome.storage.local`/`chrome.runtime.sendMessage`/`chrome.scripting`、原生 JS（无构建工具）。
+
+---
+
+## File Structure
+
+| File | Status | Responsibility |
+|---|---|---|
+| `extension/netlogger.js` | Create | webRequest 监听 + 环形缓冲 + storage 持久化 + interceptor 信号关联 + 分类逻辑 |
+| `extension/background.js` | Modify | importScripts netlogger.js；新增 NetLog 相关 runtime.onMessage 路由；转发 interceptor 信号 |
+| `extension/content.js` | Modify | 转发 interceptor 上来的 NETLOG_INTERCEPTOR_ENTRY 消息到 background |
+| `extension/interceptor.js` | Modify | 启用 netlog 时记录全量 fetch/XHR 请求/响应体，postMessage 上报 |
+| `extension/popup.html` | Modify | 加 NetLog 卡片（默认隐藏）+ tab 切换样式 + 自适应宽度 |
+| `extension/popup.js` | Modify | 标题彩蛋点击计数；NetLog 面板渲染（时序流 / 检测维度 / 详情展开 / 导出） |
+| `extension/manifest.json` | Modify | host_permissions 加风控上报域（先宽松调研，后固化） |
+
+---
+
+## Task 1: 调研风控上报域名 + 临时宽松 host_permissions
+
+**目的：** 我们不知道 XHS 实际用哪些跨域上报指纹/风控数据。先开宽松 host_permissions 监听一阵，看 chrome devtools network 抓到哪些跨域 host，再固化到 manifest。
+
+**Files:**
+- Modify: `extension/manifest.json`
+- Doc update: `docs/superpowers/specs/2026-05-19-xhs-netlogger-design.md` (回填调研结论)
+
+- [ ] **Step 1.1：在 manifest.json 加宽松调研域**
+
+修改 `extension/manifest.json` 的 `host_permissions`，临时允许所有 https，方便监听：
+
+```json
+"host_permissions": [
+  "https://www.xiaohongshu.com/*",
+  "https://xiaohongshu.com/*",
+  "https://creator.xiaohongshu.com/*",
+  "ws://localhost/*",
+  "https://*/*"
+]
+```
+
+- [ ] **Step 1.2：在 chrome://extensions 重新加载扩展**
+
+打开 `chrome://extensions/`，找到 "XHS Bridge"，点 reload 按钮。确认无错误（manifest 解析不通过会显示红色错误）。
+
+- [ ] **Step 1.3：打开 XHS 并采集跨域请求列表**
+
+- 打开 chrome devtools Network 面板，勾选 Preserve log
+- 访问 `https://www.xiaohongshu.com/`，登录账号
+- 浏览首页 30 秒（滚动几屏）
+- 搜索一个关键词，进入一个笔记详情
+- 在 Network 筛选器输入 `-domain:*.xiaohongshu.com`（过滤掉 XHS 自家域）
+- 把所有剩余请求的 host 记录到剪贴板（按 host 分组、去重）
+
+预期看到的候选：`fp.xiaohongshu.com` / `fp.snssdk.com` / `aegis.alicdn.com` / `*.bytedance.com` / `sentry.io` / `*.googleapis.com`（字体等可忽略）。
+
+- [ ] **Step 1.4：固化 host_permissions**
+
+把 Step 1.3 抓到的真实风控/上报域写入 `extension/manifest.json`（保留具体子域，不再用 `https://*/*` 宽松通配），例如：
+
+```json
+"host_permissions": [
+  "https://www.xiaohongshu.com/*",
+  "https://xiaohongshu.com/*",
+  "https://creator.xiaohongshu.com/*",
+  "https://fp.xiaohongshu.com/*",
+  "https://sec.xiaohongshu.com/*",
+  "ws://localhost/*"
+]
+```
+
+（具体最终清单按 1.3 调研结果决定。）
+
+- [ ] **Step 1.5：回填调研结论到 spec**
+
+在 `docs/superpowers/specs/2026-05-19-xhs-netlogger-design.md` 文件末尾追加 "## 附录：风控上报域名调研（2026-05-19）" 章节，列出 1.3 抓到的所有跨域 host + 一句说明（来源/可能用途）。
+
+- [ ] **Step 1.6：commit**
+
+```bash
+git add extension/manifest.json docs/superpowers/specs/2026-05-19-xhs-netlogger-design.md
+git commit -m "feat(extension): manifest 添加 XHS 风控上报域 host_permissions
+
+调研后固化的真实跨域上报 host 清单，详见 spec 附录。"
+```
+
+---
+
+## Task 2: 创建 netlogger.js 骨架（开关 + 环形缓冲 + storage）
+
+**目的：** 先把数据结构和状态管理建好，不接 webRequest（下一个 task 才接）。
+
+**Files:**
+- Create: `extension/netlogger.js`
+- Modify: `extension/background.js` (顶部加 importScripts；onMessage 加 NetLog 路由)
+
+- [ ] **Step 2.1：创建 netlogger.js 骨架**
+
+新文件 `extension/netlogger.js`：
+
+```javascript
+/**
+ * XHS NetLogger - 全量请求监听 + 检测维度归类
+ *
+ * 仅在 chrome.storage.local.netlogEnabled === true 时记录。
+ * 环形缓冲 500 条；每 10 条 / 关键事件触发写入 storage。
+ * 详细设计：docs/superpowers/specs/2026-05-19-xhs-netlogger-design.md
+ */
+
+const NETLOG_MAX_ENTRIES   = 500;
+const NETLOG_REQBODY_MAX   = 2048;
+const NETLOG_RESPBODY_MAX  = 4096;
+const NETLOG_FLUSH_EVERY_N = 10;
+const NETLOG_STORAGE_KEY   = "netLog";
+const NETLOG_ENABLED_KEY   = "netlogEnabled";
+
+const _netBuffer = [];
+const _netPending = new Map();            // requestId → 半成品 entry（跨 webRequest 4 阶段）
+let _netEnabled = false;
+let _netFlushCounter = 0;
+let _lastHostCookies = new Map();         // host → Set<cookie name> for cookieDiff
+
+function netlogIsEnabled() { return _netEnabled; }
+
+function netlogSetEnabled(v) {
+  _netEnabled = !!v;
+  chrome.storage.local.set({ [NETLOG_ENABLED_KEY]: _netEnabled });
+  if (!_netEnabled) _netPending.clear();
+}
+
+async function netlogInit() {
+  const data = await chrome.storage.local.get([NETLOG_ENABLED_KEY, NETLOG_STORAGE_KEY]);
+  _netEnabled = !!data[NETLOG_ENABLED_KEY];
+  if (Array.isArray(data[NETLOG_STORAGE_KEY])) {
+    _netBuffer.push(...data[NETLOG_STORAGE_KEY].slice(-NETLOG_MAX_ENTRIES));
+  }
+}
+
+function netlogGetAll() { return _netBuffer.slice(); }
+
+function netlogClear() {
+  _netBuffer.length = 0;
+  _netPending.clear();
+  _lastHostCookies.clear();
+  chrome.storage.local.set({ [NETLOG_STORAGE_KEY]: [] });
+}
+
+function _netlogFlush(force = false) {
+  _netFlushCounter++;
+  if (!force && _netFlushCounter % NETLOG_FLUSH_EVERY_N !== 0) return;
+  chrome.storage.local.set({ [NETLOG_STORAGE_KEY]: _netBuffer.slice(-NETLOG_MAX_ENTRIES) });
+}
+
+function _netlogPush(entry) {
+  _netBuffer.push(entry);
+  if (_netBuffer.length > NETLOG_MAX_ENTRIES) {
+    _netBuffer.splice(0, _netBuffer.length - NETLOG_MAX_ENTRIES);
+  }
+  _netlogFlush(entry.category === "business_error" ||
+               entry.category === "signature_failure" ||
+               entry.category === "risk_redirect");
+  // 通知 popup 增量
+  chrome.runtime.sendMessage({ type: "NETLOG_ENTRY_ADDED", entry }).catch(() => {});
+}
+```
+
+- [ ] **Step 2.2：background.js 顶部 importScripts**
+
+修改 `extension/background.js` 顶部（在 `const BRIDGE_URL = ...` 之前），加：
+
+```javascript
+importScripts("netlogger.js");
+netlogInit();
+```
+
+- [ ] **Step 2.3：onMessage 路由加 NetLog 接口**
+
+在 `extension/background.js` 的 `chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => { ... })` 内，在已有 case 之后（`GET_404_DIAGNOSTICS` 之后、闭合 `})` 之前）插入：
+
+```javascript
+  if (msg.type === "NETLOG_GET_ALL") {
+    sendResponse({ entries: netlogGetAll(), enabled: netlogIsEnabled() });
+    return true;
+  }
+  if (msg.type === "NETLOG_CLEAR") {
+    netlogClear();
+    sendResponse({ ok: true });
+    return true;
+  }
+  if (msg.type === "NETLOG_SET_ENABLED") {
+    netlogSetEnabled(msg.enabled);
+    sendResponse({ ok: true, enabled: netlogIsEnabled() });
+    return true;
+  }
+  if (msg.type === "NETLOG_GET_ENABLED") {
+    sendResponse({ enabled: netlogIsEnabled() });
+    return true;
+  }
+```
+
+- [ ] **Step 2.4：手工验证消息接口**
+
+reload 扩展。打开扩展 service worker 的 devtools（chrome://extensions → XHS Bridge → "service worker"），在 console 执行：
+
+```javascript
+chrome.runtime.sendMessage({ type: "NETLOG_GET_ENABLED" }, console.log);
+// 期望：{ enabled: false }
+chrome.runtime.sendMessage({ type: "NETLOG_SET_ENABLED", enabled: true }, console.log);
+// 期望：{ ok: true, enabled: true }
+chrome.runtime.sendMessage({ type: "NETLOG_GET_ALL" }, console.log);
+// 期望：{ entries: [], enabled: true }
+chrome.runtime.sendMessage({ type: "NETLOG_SET_ENABLED", enabled: false }, console.log);
+// 期望：{ ok: true, enabled: false }
+```
+
+如有任何一条返回 `undefined` 或报错，回到 Step 2.1-2.3 检查。
+
+- [ ] **Step 2.5：commit**
+
+```bash
+git add extension/netlogger.js extension/background.js
+git commit -m "feat(extension): netlogger 骨架（启用开关 + 环形缓冲 + storage）"
+```
+
+---
+
+## Task 3: webRequest 4 阶段监听 → 写入缓冲
+
+**目的：** 接通 webRequest 抓所有请求。这是 netlogger 的核心数据源。
+
+**Files:**
+- Modify: `extension/netlogger.js`
+
+- [ ] **Step 3.1：定义请求/响应 header 白名单 + cookie 提取工具**
+
+在 `extension/netlogger.js` 文件底部追加：
+
+```javascript
+const NETLOG_REQ_HEADER_WHITELIST = new Set([
+  "xs", "xt", "x-s-common", "x-t", "x-mns-platform",
+  "sec-fetch-site", "sec-fetch-mode", "sec-fetch-dest", "sec-fetch-user",
+  "referer", "origin", "user-agent",
+  "content-type", "accept", "accept-language",
+]);
+
+const NETLOG_RESP_HEADER_WHITELIST = new Set([
+  "location", "set-cookie", "cache-control", "x-request-id",
+  "content-type", "server", "x-application-context",
+]);
+
+const NETLOG_COOKIE_KEYS = ["a1", "web_session", "webId", "gid"];
+
+const NETLOG_SKIP_TYPES = new Set(["image", "font", "stylesheet", "media"]);
+
+function _filterHeaders(rawHeaders, whitelist) {
+  const out = {};
+  if (!rawHeaders) return out;
+  for (const h of rawHeaders) {
+    const k = h.name.toLowerCase();
+    if (whitelist.has(k)) {
+      // set-cookie 可能多个值，累加
+      if (k === "set-cookie" && out[k]) out[k] += "\n" + h.value;
+      else out[k] = h.value;
+    }
+  }
+  return out;
+}
+
+function _parseCookieHeader(cookieStr) {
+  const map = {};
+  if (!cookieStr) return map;
+  for (const part of cookieStr.split(";")) {
+    const i = part.indexOf("=");
+    if (i < 0) continue;
+    map[part.slice(0, i).trim()] = part.slice(i + 1).trim();
+  }
+  return map;
+}
+
+function _extractReqBody(requestBody) {
+  if (!requestBody) return null;
+  if (requestBody.raw && requestBody.raw[0] && requestBody.raw[0].bytes) {
+    try {
+      return new TextDecoder().decode(requestBody.raw[0].bytes).slice(0, NETLOG_REQBODY_MAX);
+    } catch (_) {
+      return "[binary " + requestBody.raw[0].bytes.byteLength + "B]";
+    }
+  }
+  if (requestBody.formData) {
+    try {
+      return JSON.stringify(requestBody.formData).slice(0, NETLOG_REQBODY_MAX);
+    } catch (_) { return "[formData]"; }
+  }
+  return null;
+}
+
+function _tsLabel(ts) {
+  const d = new Date(ts);
+  return String(d.getHours()).padStart(2, "0") + ":" +
+         String(d.getMinutes()).padStart(2, "0") + ":" +
+         String(d.getSeconds()).padStart(2, "0") + "." +
+         String(d.getMilliseconds()).padStart(3, "0");
+}
+```
+
+- [ ] **Step 3.2：实现 onBeforeRequest（拿 reqBody bytes）**
+
+在 `extension/netlogger.js` 底部追加：
+
+```javascript
+const NETLOG_URL_FILTER = {
+  urls: ["<all_urls>"],   // host_permissions 实际限制范围，这里全开让 webRequest 走 host_permissions 过滤
+};
+
+chrome.webRequest.onBeforeRequest.addListener(
+  (details) => {
+    if (!_netEnabled) return;
+    if (NETLOG_SKIP_TYPES.has(details.type)) return;
+
+    let host = "";
+    try { host = new URL(details.url).host; } catch (_) {}
+
+    _netPending.set(details.requestId, {
+      id: `${details.timeStamp}_${details.requestId}`,
+      requestId: details.requestId,
+      ts: details.timeStamp,
+      tsLabel: _tsLabel(details.timeStamp),
+      method: details.method,
+      url: details.url,
+      host,
+      path: (() => { try { const u = new URL(details.url); return u.pathname + (u.search || ""); } catch (_) { return details.url; } })(),
+      resourceType: details.type,
+      tabId: details.tabId,
+      reqHeaders: {},
+      reqBody: _extractReqBody(details.requestBody),
+      reqFingerprint: null,
+      status: 0,
+      statusLine: "",
+      respHeaders: {},
+      respBody: null,
+      setCookie: null,
+      duration_ms: 0,
+      err: null,
+      category: "other",
+      signals: [],
+      cookieDiff: null,
+      redirectTo: null,
+      errorCode: null,
+      _t0: Date.now(),
+    });
+  },
+  NETLOG_URL_FILTER,
+  ["requestBody"],
+);
+```
+
+- [ ] **Step 3.3：实现 onSendHeaders（拿请求头 + cookie 指纹）**
+
+在 `extension/netlogger.js` 底部追加：
+
+```javascript
+chrome.webRequest.onSendHeaders.addListener(
+  (details) => {
+    if (!_netEnabled) return;
+    const entry = _netPending.get(details.requestId);
+    if (!entry) return;
+
+    entry.reqHeaders = _filterHeaders(details.requestHeaders, NETLOG_REQ_HEADER_WHITELIST);
+
+    const cookieStr = (details.requestHeaders || []).find(h => h.name.toLowerCase() === "cookie")?.value || "";
+    const cookieMap = _parseCookieHeader(cookieStr);
+    const ua = entry.reqHeaders["user-agent"] || "";
+    entry.reqFingerprint = {
+      has_xs:        !!entry.reqHeaders["xs"],
+      has_xt:        !!entry.reqHeaders["xt"],
+      has_xsCommon:  !!entry.reqHeaders["x-s-common"],
+      sec_fetch_site: entry.reqHeaders["sec-fetch-site"] || null,
+      sec_fetch_mode: entry.reqHeaders["sec-fetch-mode"] || null,
+      referer:        entry.reqHeaders["referer"] || null,
+      origin:         entry.reqHeaders["origin"] || null,
+      ua_prefix:      ua.slice(0, 80),
+      cookie: {
+        has_a1:              "a1" in cookieMap,
+        has_web_session:     "web_session" in cookieMap,
+        has_webId:           "webId" in cookieMap,
+        has_gid:             "gid" in cookieMap,
+        a1_preview:          cookieMap["a1"]          ? cookieMap["a1"].slice(0, 12)          + "…" : null,
+        web_session_preview: cookieMap["web_session"] ? cookieMap["web_session"].slice(0, 10) + "…" : null,
+      },
+    };
+  },
+  NETLOG_URL_FILTER,
+  ["requestHeaders", "extraHeaders"],
+);
+```
+
+- [ ] **Step 3.4：实现 onHeadersReceived（拿响应头 / 状态 / set-cookie）**
+
+在 `extension/netlogger.js` 底部追加：
+
+```javascript
+chrome.webRequest.onHeadersReceived.addListener(
+  (details) => {
+    if (!_netEnabled) return;
+    const entry = _netPending.get(details.requestId);
+    if (!entry) return;
+
+    entry.status = details.statusCode;
+    entry.statusLine = (details.statusLine || "").replace(/^HTTP\/[\d.]+\s*/, "");
+    entry.respHeaders = _filterHeaders(details.responseHeaders, NETLOG_RESP_HEADER_WHITELIST);
+
+    if (entry.respHeaders["set-cookie"]) {
+      entry.setCookie = entry.respHeaders["set-cookie"]
+        .split("\n")
+        .map(s => {
+          const i = s.indexOf("=");
+          return i > 0 ? s.slice(0, i).trim() : s.trim();
+        });
+    }
+
+    if (details.statusCode === 301 || details.statusCode === 302) {
+      entry.redirectTo = entry.respHeaders["location"] || null;
+      if (entry.redirectTo) {
+        try {
+          const loc = new URL(entry.redirectTo, details.url);
+          entry.errorCode = loc.searchParams.get("error_code");
+        } catch (_) {}
+      }
+    }
+  },
+  NETLOG_URL_FILTER,
+  ["responseHeaders", "extraHeaders"],
+);
+```
+
+- [ ] **Step 3.5：实现 onCompleted + onErrorOccurred（finalize 入栈）**
+
+在 `extension/netlogger.js` 底部追加：
+
+```javascript
+function _netlogFinalize(details, isError) {
+  if (!_netEnabled) return;
+  const entry = _netPending.get(details.requestId);
+  _netPending.delete(details.requestId);
+  if (!entry) return;
+  entry.duration_ms = Date.now() - entry._t0;
+  delete entry._t0;
+  if (isError) entry.err = details.error || "network_error";
+  // 分类逻辑由后续 task 5 接入
+  _netlogPush(entry);
+}
+
+chrome.webRequest.onCompleted.addListener(
+  (d) => _netlogFinalize(d, false),
+  NETLOG_URL_FILTER,
+);
+chrome.webRequest.onErrorOccurred.addListener(
+  (d) => _netlogFinalize(d, true),
+  NETLOG_URL_FILTER,
+);
+```
+
+- [ ] **Step 3.6：手工验证 webRequest 抓到了请求**
+
+reload 扩展。在 service worker devtools console 执行：
+
+```javascript
+chrome.runtime.sendMessage({ type: "NETLOG_SET_ENABLED", enabled: true });
+chrome.runtime.sendMessage({ type: "NETLOG_CLEAR" });
+```
+
+打开 https://www.xiaohongshu.com/，浏览 10 秒。再回 SW console 执行：
+
+```javascript
+chrome.runtime.sendMessage({ type: "NETLOG_GET_ALL" }, r => console.log(r.entries.length, r.entries.slice(0, 3)));
+```
+
+预期：`entries.length > 0`，输出 3 条样本，包含 method/url/status/reqFingerprint.cookie/respHeaders。如 entries 是空，回 Step 3.2-3.5 检查。
+
+- [ ] **Step 3.7：commit**
+
+```bash
+git add extension/netlogger.js
+git commit -m "feat(extension): netlogger 接入 webRequest 4 阶段监听"
+```
+
+---
+
+## Task 4: interceptor.js 全量 hook + 响应体上报
+
+**目的：** webRequest 拿不到响应体，业务域内通过 fetch/XHR hook 补齐。
+
+**Files:**
+- Modify: `extension/interceptor.js`
+- Modify: `extension/content.js`
+- Modify: `extension/background.js`
+- Modify: `extension/netlogger.js` (接收 interceptor 信号 + 关联)
+
+- [ ] **Step 4.1：interceptor.js 加 netlog 启用状态同步**
+
+修改 `extension/interceptor.js` —— 在文件顶部 IIFE 内、`const BLOCKED = new Set([404, 461, 403, 999]);` 后面，添加：
+
+```javascript
+  let _netlogEnabled = false;
+  const RESP_BODY_MAX = 4096;
+
+  // 通过 storage 同步 netlog 启用状态（MAIN world 不能直接读 chrome.storage）
+  // content.js 监听 storage.local 变化，postMessage 给我们
+  window.addEventListener("message", (e) => {
+    if (e.data?.source === "xhs-netlog-status") {
+      _netlogEnabled = !!e.data.enabled;
+    }
+  });
+```
+
+- [ ] **Step 4.2：interceptor.js 在 fetch hook 内增加全量上报**
+
+修改 `extension/interceptor.js` 的 `window.fetch = async function (...) { ... }`，在 `const resp = await _fetch.call(this, input, init);` 之后插入响应体抓取逻辑：
+
+```javascript
+    const resp = await _fetch.call(this, input, init);
+
+    // 现有 BLOCKED 诊断保持不变
+    if (BLOCKED.has(resp.status) && (isApiUrl(url) || url.includes("xiaohongshu.com"))) {
+      emit(buildEvent(url, method, resp.status, headers, { intercept_type: "fetch" }));
+    }
+
+    // NetLog 全量记录（仅启用时）
+    if (_netlogEnabled && url.includes("xiaohongshu.com")) {
+      let respBody = null;
+      try {
+        const clone = resp.clone();
+        const text = await clone.text();
+        respBody = text.length > RESP_BODY_MAX ? text.slice(0, RESP_BODY_MAX) + "…[cut]" : text;
+      } catch (_) { respBody = "[unreadable]"; }
+
+      window.postMessage({
+        source: "xhs-netlog-intercept",
+        method,
+        url,
+        status: resp.status,
+        reqHeaders: headers,
+        respBody,
+        ts: Date.now(),
+      }, "*");
+    }
+
+    return resp;
+  };
+```
+
+- [ ] **Step 4.3：interceptor.js 在 XHR hook 内增加全量上报**
+
+修改 `extension/interceptor.js` 的 `XMLHttpRequest.prototype.send = function () { ... }`，在 `loadend` 监听器内现有 BLOCKED 逻辑之后添加：
+
+```javascript
+  XMLHttpRequest.prototype.send = function () {
+    this.addEventListener("loadend", () => {
+      const url = this.__i_url || "";
+
+      // 现有 BLOCKED 诊断保持不变
+      if (BLOCKED.has(this.status) && (isApiUrl(url) || url.includes("xiaohongshu.com"))) {
+        emit(buildEvent(url, this.__i_method || "GET", this.status, this.__i_headers || {}, {
+          intercept_type: "xhr",
+        }));
+      }
+
+      // NetLog 全量记录
+      if (_netlogEnabled && url.includes("xiaohongshu.com")) {
+        let respBody = null;
+        try {
+          const t = this.responseText || "";
+          respBody = t.length > RESP_BODY_MAX ? t.slice(0, RESP_BODY_MAX) + "…[cut]" : t;
+        } catch (_) { respBody = "[unreadable]"; }
+
+        window.postMessage({
+          source: "xhs-netlog-intercept",
+          method: this.__i_method || "GET",
+          url,
+          status: this.status,
+          reqHeaders: this.__i_headers || {},
+          respBody,
+          ts: Date.now(),
+        }, "*");
+      }
+    });
+    return _xhrSend.apply(this, arguments);
+  };
+```
+
+- [ ] **Step 4.4：content.js 转发 interceptor 信号 + 同步启用状态**
+
+修改 `extension/content.js`，在文件底部追加（或合并到已有 message 监听器内 — 看现有结构决定）：
+
+```javascript
+// ─── NetLog 信号转发 + 启用状态同步 ──────────────────────────────
+
+// MAIN world interceptor → content (postMessage) → background (runtime)
+window.addEventListener("message", (e) => {
+  if (e.source !== window) return;
+  if (e.data?.source === "xhs-netlog-intercept") {
+    chrome.runtime.sendMessage({
+      type: "NETLOG_INTERCEPTOR_ENTRY",
+      payload: e.data,
+    }).catch(() => {});
+  }
+});
+
+// 启动时同步 netlog 启用状态到 MAIN world
+function _syncNetlogStatus() {
+  chrome.runtime.sendMessage({ type: "NETLOG_GET_ENABLED" }, (resp) => {
+    window.postMessage({ source: "xhs-netlog-status", enabled: !!resp?.enabled }, "*");
+  });
+}
+_syncNetlogStatus();
+
+// 监听 background 推送的启用状态变化
+chrome.runtime.onMessage.addListener((msg) => {
+  if (msg.type === "NETLOG_ENABLED_CHANGED") {
+    window.postMessage({ source: "xhs-netlog-status", enabled: !!msg.enabled }, "*");
+  }
+});
+```
+
+- [ ] **Step 4.5：background.js 接 interceptor 信号 + 广播状态变化**
+
+修改 `extension/background.js` 的 `chrome.runtime.onMessage.addListener` 内，在 NetLog 路由块（Step 2.3 加的）后面添加：
+
+```javascript
+  if (msg.type === "NETLOG_INTERCEPTOR_ENTRY") {
+    netlogIngestInterceptor(msg.payload);
+    return false;
+  }
+```
+
+并修改 `netlogSetEnabled` 调用点（找到 `NETLOG_SET_ENABLED` 路由），加广播：
+
+```javascript
+  if (msg.type === "NETLOG_SET_ENABLED") {
+    netlogSetEnabled(msg.enabled);
+    chrome.tabs.query({ url: ["*://*.xiaohongshu.com/*"] }, (tabs) => {
+      for (const t of tabs) {
+        chrome.tabs.sendMessage(t.id, { type: "NETLOG_ENABLED_CHANGED", enabled: msg.enabled }).catch(() => {});
+      }
+    });
+    sendResponse({ ok: true, enabled: netlogIsEnabled() });
+    return true;
+  }
+```
+
+- [ ] **Step 4.6：netlogger.js 实现 ingestInterceptor（关联回填）**
+
+在 `extension/netlogger.js` 底部追加：
+
+```javascript
+const NETLOG_INTERCEPTOR_WINDOW_MS = 2000;
+
+function netlogIngestInterceptor(payload) {
+  if (!_netEnabled || !payload) return;
+
+  // 在最近 2s 内倒序找匹配 (method + url)，给该 entry 填响应体
+  for (let i = _netBuffer.length - 1; i >= 0; i--) {
+    const e = _netBuffer[i];
+    if (payload.ts - e.ts > NETLOG_INTERCEPTOR_WINDOW_MS) break;
+    if (e.method === payload.method && e.url === payload.url && !e.respBody) {
+      e.respBody = payload.respBody;
+      // 合并 interceptor 头（webRequest 拿不到的应用层头）
+      for (const [k, v] of Object.entries(payload.reqHeaders || {})) {
+        const lk = k.toLowerCase();
+        if (!e.reqHeaders[lk]) e.reqHeaders[lk] = v;
+      }
+      return;
+    }
+  }
+
+  // 没关联上，独立存
+  _netlogPush({
+    id: `${payload.ts}_intercept`,
+    requestId: "",
+    ts: payload.ts,
+    tsLabel: _tsLabel(payload.ts),
+    method: payload.method,
+    url: payload.url,
+    host: (() => { try { return new URL(payload.url).host; } catch (_) { return ""; } })(),
+    path: (() => { try { const u = new URL(payload.url); return u.pathname + (u.search || ""); } catch (_) { return payload.url; } })(),
+    resourceType: "xmlhttprequest",
+    tabId: -1,
+    reqHeaders: payload.reqHeaders || {},
+    reqBody: null,
+    reqFingerprint: null,
+    status: payload.status,
+    statusLine: "",
+    respHeaders: {},
+    respBody: payload.respBody,
+    setCookie: null,
+    duration_ms: 0,
+    err: null,
+    category: "other",
+    signals: [],
+    cookieDiff: null,
+    redirectTo: null,
+    errorCode: null,
+    _orphan: true,
+  });
+}
+```
+
+- [ ] **Step 4.7：手工验证响应体关联**
+
+reload 扩展。SW console 启用：
+
+```javascript
+chrome.runtime.sendMessage({ type: "NETLOG_CLEAR" });
+chrome.runtime.sendMessage({ type: "NETLOG_SET_ENABLED", enabled: true });
+```
+
+刷新 xiaohongshu.com 首页，浏览 10 秒。SW console 查：
+
+```javascript
+chrome.runtime.sendMessage({ type: "NETLOG_GET_ALL" }, r => {
+  const withBody = r.entries.filter(e => e.respBody);
+  console.log("总", r.entries.length, "有响应体", withBody.length, withBody[0]);
+});
+```
+
+预期：xiaohongshu.com 域请求至少 30% 有 `respBody`（业务域 fetch/XHR 会被关联回填）。如全为 null，回 Step 4.1-4.6 检查；常见问题：interceptor world 没设 MAIN（manifest.json content_scripts[0].world）/ postMessage source 拼写不一致。
+
+- [ ] **Step 4.8：commit**
+
+```bash
+git add extension/interceptor.js extension/content.js extension/background.js extension/netlogger.js
+git commit -m "feat(extension): interceptor 全量 fetch/XHR hook 抓响应体，关联回填 netlog"
+```
+
+---
+
+## Task 5: 检测维度分类 + cookieDiff
+
+**目的：** 把入栈前的 entry 自动归类（category）和打信号（signals），为 popup 检测维度 tab 提供数据。
+
+**Files:**
+- Modify: `extension/netlogger.js`
+
+- [ ] **Step 5.1：实现 classify + cookieDiff 函数**
+
+在 `extension/netlogger.js` 文件底部追加：
+
+```javascript
+const NETLOG_FP_HOST_KEYWORDS = ["fp", "sec", "aegis", "sentry", "track", "log"];
+const NETLOG_FP_BODY_KEYWORDS = ["webdriver", "navigator", "screen", "timezone", "platform"];
+
+function _netlogClassify(entry) {
+  const signals = [];
+  let category = "other";
+
+  const hostLow = entry.host.toLowerCase();
+  const isFpHost = NETLOG_FP_HOST_KEYWORDS.some(kw => hostLow.includes(kw));
+  const bodyLow = (entry.reqBody || "").toLowerCase();
+  const fpBodyHit = NETLOG_FP_BODY_KEYWORDS.find(kw => bodyLow.includes(kw));
+
+  // 优先级：signature_failure > risk_redirect > business_error > fingerprint_upload > cookie_change > business_api > page_nav > other
+  if (entry.errorCode && /^30003[123]$/.test(entry.errorCode)) {
+    category = "signature_failure";
+    signals.push(`error_code:${entry.errorCode}`);
+  } else if (entry.redirectTo && /\/(404|login)(\/|\?|$)/.test(entry.redirectTo)) {
+    category = "risk_redirect";
+    signals.push(`redirect:${entry.redirectTo.slice(0, 60)}`);
+  } else if ([401, 403, 461, 999].includes(entry.status)) {
+    category = "business_error";
+    signals.push(`status:${entry.status}`);
+  } else if (isFpHost || fpBodyHit) {
+    category = "fingerprint_upload";
+    signals.push("fingerprint_upload");
+    if (fpBodyHit) signals.push(`body_contains:${fpBodyHit}`);
+  } else if (entry.setCookie && entry.setCookie.length > 0) {
+    // cookie_change 由 cookieDiff 进一步判断（见下）
+    category = "other";
+  } else if (entry.resourceType === "main_frame") {
+    category = "page_nav";
+  } else if (entry.path && entry.path.includes("/api/") && entry.status >= 200 && entry.status < 300) {
+    category = "business_api";
+  }
+
+  return { category, signals };
+}
+
+function _netlogComputeCookieDiff(entry) {
+  if (!entry.setCookie || entry.setCookie.length === 0) return null;
+  const prev = _lastHostCookies.get(entry.host) || new Set();
+  const curr = new Set(entry.setCookie);
+  const added = [...curr].filter(k => !prev.has(k));
+  const removed = [...prev].filter(k => !curr.has(k));
+  _lastHostCookies.set(entry.host, curr);
+  if (added.length === 0 && removed.length === 0) return null;
+  return { added, removed, changed: [] };
+}
+```
+
+- [ ] **Step 5.2：在 finalize 时调用 classify + cookieDiff**
+
+修改 `extension/netlogger.js` 的 `_netlogFinalize` 函数（Step 3.5 写的），在 `_netlogPush(entry)` 之前插入分类逻辑：
+
+```javascript
+function _netlogFinalize(details, isError) {
+  if (!_netEnabled) return;
+  const entry = _netPending.get(details.requestId);
+  _netPending.delete(details.requestId);
+  if (!entry) return;
+  entry.duration_ms = Date.now() - entry._t0;
+  delete entry._t0;
+  if (isError) entry.err = details.error || "network_error";
+
+  // 分类 + cookieDiff
+  const { category, signals } = _netlogClassify(entry);
+  entry.category = category;
+  entry.signals = signals;
+  entry.cookieDiff = _netlogComputeCookieDiff(entry);
+  if (entry.cookieDiff) {
+    entry.category = entry.category === "other" ? "cookie_change" : entry.category;
+    entry.signals.push("set_cookie_changed:" + entry.cookieDiff.added.join(","));
+  }
+
+  _netlogPush(entry);
+}
+```
+
+同样在 `netlogIngestInterceptor` 的 orphan 分支（Step 4.6）里，在 `_netlogPush(...)` 之前给 orphan entry 也跑一次分类：
+
+修改 `extension/netlogger.js` 的 `netlogIngestInterceptor`，在构造 orphan entry 之后、`_netlogPush(...)` 之前插入：
+
+```javascript
+  // orphan 也跑分类
+  const orphanEntry = /* 上面构造的对象 */;  // 提取到变量
+  const { category, signals } = _netlogClassify(orphanEntry);
+  orphanEntry.category = category;
+  orphanEntry.signals = signals;
+  _netlogPush(orphanEntry);
+```
+
+具体改法：把 Step 4.6 中 `_netlogPush({ ... })` 改成：
+
+```javascript
+  const orphanEntry = {
+    id: `${payload.ts}_intercept`,
+    requestId: "",
+    /* ...原 Step 4.6 中所有字段 ... */
+    _orphan: true,
+  };
+  const { category, signals } = _netlogClassify(orphanEntry);
+  orphanEntry.category = category;
+  orphanEntry.signals = signals;
+  _netlogPush(orphanEntry);
+```
+
+- [ ] **Step 5.3：手工验证分类结果**
+
+reload 扩展。SW console：
+
+```javascript
+chrome.runtime.sendMessage({ type: "NETLOG_CLEAR" });
+chrome.runtime.sendMessage({ type: "NETLOG_SET_ENABLED", enabled: true });
+```
+
+打开 xiaohongshu.com，浏览 + 搜索 30 秒。再访问一个 fake 笔记 URL（去掉 xsec_token）：`https://www.xiaohongshu.com/explore/abc1234567890`。
+
+SW console 查分类汇总：
+
+```javascript
+chrome.runtime.sendMessage({ type: "NETLOG_GET_ALL" }, r => {
+  const groups = {};
+  for (const e of r.entries) groups[e.category] = (groups[e.category] || 0) + 1;
+  console.log("分类汇总", groups);
+  console.log("signature_failure 样本:", r.entries.find(e => e.category === "signature_failure"));
+});
+```
+
+预期：至少出现 `business_api / page_nav / risk_redirect` 或 `signature_failure`（手工触发的 fake URL 应当落入后两类之一）。
+
+- [ ] **Step 5.4：commit**
+
+```bash
+git add extension/netlogger.js
+git commit -m "feat(extension): netlogger 加入分类 + cookieDiff 逻辑"
+```
+
+---
+
+## Task 6: popup UI - 彩蛋激活 + NetLog 卡片 + 时序流
+
+**目的：** popup 标题连点 5 次激活 NetLog；激活后 popup 增宽，下方显示时序流。
+
+**Files:**
+- Modify: `extension/popup.html`
+- Modify: `extension/popup.js`
+
+- [ ] **Step 6.1：popup.html 添加 NetLog 卡片骨架（默认隐藏）+ 自适应宽度样式**
+
+修改 `extension/popup.html`。
+
+将 `body { width: 220px; ... }` 改为：
+
+```css
+body {
+  width: 220px;
+  padding: 16px;
+  font-family: -apple-system, "PingFang SC", "Microsoft YaHei", sans-serif;
+  font-size: 13px;
+  color: #333;
+  margin: 0;
+  transition: width 0.2s;
+}
+body.netlog-on { width: 580px; }
+```
+
+并在 `<style>` 末尾追加 NetLog 专属样式：
+
+```css
+.netlog-card { display: none; }
+body.netlog-on .netlog-card { display: block; }
+.netlog-tabs { display: flex; gap: 4px; margin-bottom: 6px; }
+.netlog-tab {
+  padding: 3px 10px;
+  font-size: 11px;
+  cursor: pointer;
+  border-radius: 4px;
+  background: #f1f3f4;
+  color: #555;
+}
+.netlog-tab.active { background: #1a73e8; color: #fff; }
+.netlog-row {
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  font-size: 10px;
+  line-height: 1.5;
+  padding: 2px 4px;
+  border-radius: 3px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  cursor: pointer;
+}
+.netlog-row:hover { background: #f8f9fa; }
+.netlog-row.cat-fingerprint_upload { color: #b7950b; }
+.netlog-row.cat-business_error,
+.netlog-row.cat-risk_redirect,
+.netlog-row.cat-signature_failure { color: #c5221f; }
+.netlog-row.cat-cookie_change { color: #1565c0; }
+.netlog-list { max-height: 320px; overflow-y: auto; border: 1px solid #eee; padding: 4px; border-radius: 4px; }
+.netlog-detail {
+  background: #fafafa;
+  border: 1px solid #eee;
+  border-radius: 4px;
+  padding: 6px;
+  margin-top: 6px;
+  font-family: ui-monospace, monospace;
+  font-size: 10px;
+  max-height: 200px;
+  overflow-y: auto;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+.netlog-toolbar { display: flex; gap: 6px; margin-bottom: 6px; }
+.netlog-toolbar button {
+  flex: 1;
+  padding: 3px 0;
+  font-size: 11px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  background: #fff;
+  cursor: pointer;
+}
+```
+
+在 `<body>` 内、`<script type="module" src="popup.js"></script>` 之前追加 NetLog 卡片 HTML：
+
+```html
+<hr class="divider">
+<div class="netlog-card">
+  <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:6px">
+    <span style="font-size:12px;font-weight:600;color:#333">NetLog</span>
+    <span style="font-size:10px;color:#888" id="netlog-count">0 条</span>
+  </div>
+  <div class="netlog-tabs">
+    <div class="netlog-tab active" data-tab="stream">时序流</div>
+    <div class="netlog-tab" data-tab="category">检测维度</div>
+  </div>
+  <div class="netlog-toolbar">
+    <button id="netlog-clear">清空</button>
+    <button id="netlog-export">导出 JSON</button>
+    <button id="netlog-disable">关闭</button>
+  </div>
+  <div class="netlog-list" id="netlog-list"></div>
+  <div class="netlog-detail" id="netlog-detail" style="display:none"></div>
+</div>
+```
+
+将原 `<h3>XHS Bridge</h3>` 改为可点击标题：
+
+```html
+<h3 id="title-hit" style="cursor:default;user-select:none">XHS Bridge</h3>
+```
+
+- [ ] **Step 6.2：popup.js 加彩蛋点击逻辑 + 启用状态读取**
+
+在 `extension/popup.js` 文件底部追加：
+
+```javascript
+// ─── NetLog 彩蛋激活 + 状态 ──────────────────────────────────────
+
+const NETLOG_HIT_TARGET = 5;
+const NETLOG_HIT_RESET_MS = 500;
+let _netlogHits = 0;
+let _netlogHitTimer = null;
+
+const titleEl = document.getElementById("title-hit");
+titleEl?.addEventListener("click", () => {
+  _netlogHits++;
+  clearTimeout(_netlogHitTimer);
+  _netlogHitTimer = setTimeout(() => { _netlogHits = 0; }, NETLOG_HIT_RESET_MS);
+  if (_netlogHits >= NETLOG_HIT_TARGET) {
+    _netlogHits = 0;
+    chrome.runtime.sendMessage({ type: "NETLOG_GET_ENABLED" }, (resp) => {
+      if (resp?.enabled) {
+        if (confirm("关闭 NetLog?")) toggleNetlog(false);
+      } else {
+        toggleNetlog(true);
+      }
+    });
+  }
+});
+
+function toggleNetlog(enabled) {
+  chrome.runtime.sendMessage({ type: "NETLOG_SET_ENABLED", enabled }, () => {
+    applyNetlogUI(enabled);
+    if (enabled) refreshNetlog();
+  });
+}
+
+function applyNetlogUI(enabled) {
+  document.body.classList.toggle("netlog-on", !!enabled);
+}
+
+// 初始化：根据当前启用状态决定显示
+chrome.runtime.sendMessage({ type: "NETLOG_GET_ENABLED" }, (resp) => {
+  if (resp?.enabled) {
+    applyNetlogUI(true);
+    refreshNetlog();
+  }
+});
+
+document.getElementById("netlog-disable")?.addEventListener("click", () => toggleNetlog(false));
+document.getElementById("netlog-clear")?.addEventListener("click", () => {
+  chrome.runtime.sendMessage({ type: "NETLOG_CLEAR" }, () => refreshNetlog());
+});
+```
+
+- [ ] **Step 6.3：popup.js 加时序流渲染 + 实时增量**
+
+在 `extension/popup.js` 文件底部继续追加：
+
+```javascript
+// ─── NetLog 时序流渲染 ──────────────────────────────────────────
+
+let _netlogEntries = [];
+let _netlogTab = "stream";
+
+function refreshNetlog() {
+  chrome.runtime.sendMessage({ type: "NETLOG_GET_ALL" }, (resp) => {
+    _netlogEntries = resp?.entries || [];
+    renderNetlog();
+  });
+}
+
+function renderNetlog() {
+  const countEl = document.getElementById("netlog-count");
+  if (countEl) countEl.textContent = `${_netlogEntries.length} 条`;
+
+  const list = document.getElementById("netlog-list");
+  if (!list) return;
+
+  if (_netlogTab === "stream") {
+    renderNetlogStream(list);
+  } else {
+    renderNetlogCategory(list);
+  }
+}
+
+const NETLOG_CAT_LABEL = {
+  fingerprint_upload: "指纹↑",
+  business_error: "错误",
+  risk_redirect: "风控跳",
+  signature_failure: "签名失败",
+  cookie_change: "Cookie 变",
+  business_api: "API",
+  page_nav: "导航",
+  other: "其他",
+};
+
+function renderNetlogStream(container) {
+  // 最新在底，倒序展示前 200 条
+  const slice = _netlogEntries.slice(-200);
+  container.innerHTML = slice.map((e, i) => {
+    const star = (e.category === "fingerprint_upload" || e.category === "risk_redirect" ||
+                  e.category === "signature_failure") ? " ★" : "";
+    const path = e.path.length > 50 ? e.path.slice(0, 47) + "…" : e.path;
+    const host = e.host.replace(/^www\./, "");
+    return `<div class="netlog-row cat-${e.category}" data-idx="${i}">
+      ${e.tsLabel}  ${e.method.padEnd(4)} ${e.status || "?"}  ${e.duration_ms}ms  ${host}${path}  [${NETLOG_CAT_LABEL[e.category]}]${star}
+    </div>`;
+  }).join("");
+
+  // 点击展开详情
+  container.querySelectorAll(".netlog-row").forEach(row => {
+    row.addEventListener("click", () => {
+      const idx = Number(row.dataset.idx);
+      showNetlogDetail(slice[idx]);
+    });
+  });
+  // 滚到底
+  container.scrollTop = container.scrollHeight;
+}
+
+function showNetlogDetail(entry) {
+  const el = document.getElementById("netlog-detail");
+  if (!el) return;
+  el.style.display = "block";
+  el.textContent = JSON.stringify(entry, null, 2);
+}
+
+// tab 切换
+document.querySelectorAll(".netlog-tab").forEach(tab => {
+  tab.addEventListener("click", () => {
+    document.querySelectorAll(".netlog-tab").forEach(t => t.classList.remove("active"));
+    tab.classList.add("active");
+    _netlogTab = tab.dataset.tab;
+    renderNetlog();
+  });
+});
+
+// 实时增量
+chrome.runtime.onMessage.addListener((msg) => {
+  if (msg.type === "NETLOG_ENTRY_ADDED" && document.body.classList.contains("netlog-on")) {
+    _netlogEntries.push(msg.entry);
+    if (_netlogEntries.length > 500) _netlogEntries.splice(0, _netlogEntries.length - 500);
+    renderNetlog();
+  }
+});
+```
+
+- [ ] **Step 6.4：手工验证彩蛋激活 + 时序流**
+
+reload 扩展。点击工具栏图标打开 popup。点击 "XHS Bridge" 标题 5 次（500ms 内连点）。预期：popup 立即扩宽到 580px；底部出现 NetLog 卡片；如果之前 task 步骤里有跑过 xhs 浏览，应有时序流条目。打开 xiaohongshu.com 让请求发起，popup 时序流应该实时增加。
+
+如果点 5 次后没激活：在 popup devtools（右键 popup → Inspect）console 看 `_netlogHits` 计数有没有累加，常见问题：title-hit id 没生效 / click handler 没绑定。
+
+- [ ] **Step 6.5：commit**
+
+```bash
+git add extension/popup.html extension/popup.js
+git commit -m "feat(extension): popup 加彩蛋激活 + NetLog 时序流面板"
+```
+
+---
+
+## Task 7: popup UI - 检测维度 tab + JSON 导出
+
+**目的：** "检测维度" tab 按 category 聚合展示；"导出 JSON" 把缓冲全量导出为下载文件。
+
+**Files:**
+- Modify: `extension/popup.js`
+
+- [ ] **Step 7.1：popup.js 添加按 category 分组渲染**
+
+在 `extension/popup.js` 的 `renderNetlogStream` 函数之后追加：
+
+```javascript
+function renderNetlogCategory(container) {
+  const groups = {};
+  for (const e of _netlogEntries) {
+    if (!groups[e.category]) groups[e.category] = [];
+    groups[e.category].push(e);
+  }
+
+  const order = ["fingerprint_upload", "signature_failure", "risk_redirect",
+                 "business_error", "cookie_change", "business_api", "page_nav", "other"];
+
+  const sections = [];
+  for (const cat of order) {
+    if (!groups[cat] || groups[cat].length === 0) continue;
+    const label = NETLOG_CAT_LABEL[cat];
+    const items = groups[cat].slice(-50);  // 每类最多展示 50 条
+    sections.push(`
+      <details open style="margin-bottom:6px">
+        <summary style="cursor:pointer;font-size:11px;font-weight:600;color:#444">▾ ${label} (${groups[cat].length})</summary>
+        ${items.map((e, i) => {
+          const path = e.path.length > 60 ? e.path.slice(0, 57) + "…" : e.path;
+          const signal = (e.signals || []).slice(0, 2).join(", ");
+          return `<div class="netlog-row cat-${e.category}" data-cat="${cat}" data-idx="${i}">
+            ${e.tsLabel}  ${e.method.padEnd(4)} ${e.status || "?"}  ${e.host.replace(/^www\./, "")}${path}${signal ? "  ["+signal+"]" : ""}
+          </div>`;
+        }).join("")}
+      </details>
+    `);
+  }
+
+  container.innerHTML = sections.join("") || '<div style="color:#aaa;font-size:11px;padding:8px">暂无数据</div>';
+
+  // 详情点击：data-cat + data-idx 反查
+  container.querySelectorAll(".netlog-row").forEach(row => {
+    row.addEventListener("click", () => {
+      const cat = row.dataset.cat;
+      const idx = Number(row.dataset.idx);
+      const entry = groups[cat]?.slice(-50)[idx];
+      if (entry) showNetlogDetail(entry);
+    });
+  });
+}
+```
+
+- [ ] **Step 7.2：popup.js 添加 JSON 导出**
+
+在 `extension/popup.js` 文件底部追加：
+
+```javascript
+document.getElementById("netlog-export")?.addEventListener("click", () => {
+  const blob = new Blob([JSON.stringify(_netlogEntries, null, 2)], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `xhs-netlog-${new Date().toISOString().replace(/[:.]/g, "-")}.json`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+});
+```
+
+- [ ] **Step 7.3：手工验证检测维度 + 导出**
+
+reload 扩展。打开 popup（NetLog 已激活态会自动恢复）。打开 xhs 浏览 30 秒。
+- 点击 "检测维度" tab → 预期看到几个折叠分组（fingerprint_upload / business_api / page_nav / 等），每个分组下有条目；点击条目 → 详情区显示 JSON。
+- 点击 "导出 JSON" → 浏览器下载一个文件名形如 `xhs-netlog-2026-05-19T...json` 的文件，打开能看到所有 entries。
+
+- [ ] **Step 7.4：commit**
+
+```bash
+git add extension/popup.js
+git commit -m "feat(extension): popup NetLog 检测维度 tab + JSON 导出"
+```
+
+---
+
+## Task 8: 端到端冒烟 + 调研结果回填
+
+**目的：** 完整跑通 spec 列出的所有场景，证明 netlogger 能反映检测维度。
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-05-19-xhs-netlogger-design.md`（追加冒烟报告）
+
+- [ ] **Step 8.1：浏览场景**
+
+1. 关浏览器再开（验证扩展重启不丢启用状态）
+2. 打开 popup，确认 NetLog 已激活（因 storage 持久）
+3. 打开 xhs 首页，滚动 30 秒
+4. 切到 "检测维度" tab，确认看到 `fingerprint_upload` 类目（如果没有，说明 host_permissions 没覆盖到实际上报域，回 Task 1 复查）
+
+- [ ] **Step 8.2：故意触发 signature_failure**
+
+清空 NetLog，在地址栏直接输入：`https://www.xiaohongshu.com/explore/65000000000000000000000a`（无 xsec_token 的伪笔记 URL）。预期 NetLog 时序流出现 302 重定向到 `/404?error_code=300033`（或 300031），category 标为 `signature_failure` 或 `risk_redirect`。
+
+- [ ] **Step 8.3：账号切换触发 clear**（本期未实现，留作后续验证）
+
+**注意：** spec 提到 "用户切换账号（a1 变化）→ 触发自动 clear"，但当前 plan 没有任务实现这个逻辑（避免本期 scope 膨胀）。在本步骤里跳过验证，把 "账号切换自动 clear" 作为已知 follow-up 列入 spec 附录的 "已知限制" 章节。
+
+- [ ] **Step 8.4：性能观察**
+
+不启用 NetLog vs 启用 NetLog，分别在 xhs 首页滚动 30s，打开 chrome://serviceworker-internals/ 看扩展 SW 的 CPU 占用（人工对比）。预期启用后偶发尖峰、稳态低（< 5%）。
+
+- [ ] **Step 8.5：把冒烟结果写入 spec 附录**
+
+在 `docs/superpowers/specs/2026-05-19-xhs-netlogger-design.md` 末尾追加：
+
+```markdown
+## 附录：实施后冒烟结果（2026-05-19）
+
+- Task 8.1 浏览首页：时序流 ~80 条，检测维度 tab 分布合理（business_api/page_nav 占多数，fingerprint_upload N 条，cookie_change M 条）。
+- Task 8.2 signature_failure：实测触发 error_code=____ ，分类正确。
+- Task 8.3 账号切换自动 clear：本期未实现，列入已知限制。
+- Task 8.4 性能：启用后 SW CPU 偶发 X%，稳态 Y%。
+
+## 已知限制（截至 2026-05-19）
+
+- 账号切换不自动 clear（用户需手动清空）
+- 无 CLI 暴露（用户决定）
+- 跨域风控上报域响应体看不到（chrome.webRequest 限制）
+- 同一 url 短时间高并发请求时关联可能漏配（2s 时间窗 + url 完全匹配）
+```
+
+把 `____` / `X` / `Y` 等占位换成实际观测值。
+
+- [ ] **Step 8.6：commit**
+
+```bash
+git add docs/superpowers/specs/2026-05-19-xhs-netlogger-design.md
+git commit -m "docs: 回填 XHS netlogger 冒烟结果与已知限制"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage check（spec 章节 → plan 任务）：**
+
+| Spec 章节 | 对应 Task |
+|---|---|
+| 目标 / 非目标 | 整体 plan |
+| 选定方案 B | Task 2-5（webRequest + interceptor 融合） |
+| 组件结构 | 全部 Task |
+| 数据流 | Task 3 + Task 4 |
+| 启用开关 / 彩蛋激活 | Task 2 (开关) + Task 6 (彩蛋) |
+| interceptor ↔ netlogger 关联 | Task 4 |
+| 检测维度自动分类 | Task 5 |
+| 性能与容量 | Task 3 (skip types) + Task 5 (分类) + Task 8 (性能验证) |
+| NetLogEntry schema | Task 3 (基础) + Task 4 (响应体) + Task 5 (分类字段) |
+| popup NetLog 面板草图 | Task 6 (HTML+时序流) + Task 7 (检测维度+导出) |
+| 错误处理 & 边缘情况 | 分散在各 Task；账号切换自动 clear 显式标为已知限制 |
+| 实现顺序与工作量 | 严格按 spec 的 8 个 task |
+| 测试方案 | Task 8 |
+
+**Placeholder scan：** 无 TBD / TODO；Step 8.5 的 `____` / `X` / `Y` 是执行时填入的占位符（合理，由实施者用实测值替换）。
+
+**Type consistency：**
+- `_netEnabled` / `_netBuffer` / `_netPending` / `_lastHostCookies` 在 Task 2 定义，Task 3-5 一致使用
+- `NETLOG_STORAGE_KEY` / `NETLOG_ENABLED_KEY` 在 Task 2 定义，Task 4 中通过相同 message type 间接使用
+- message type 名一致：`NETLOG_GET_ALL` / `NETLOG_SET_ENABLED` / `NETLOG_GET_ENABLED` / `NETLOG_CLEAR` / `NETLOG_ENTRY_ADDED` / `NETLOG_ENABLED_CHANGED` / `NETLOG_INTERCEPTOR_ENTRY`
+- category 枚举值一致：`fingerprint_upload` / `business_error` / `risk_redirect` / `signature_failure` / `cookie_change` / `business_api` / `page_nav` / `other`
+
+**已知偏离 TDD：** 见文档头部说明（spec 决定不写自动化测试）。每个 task 用手工验证步骤代替。

--- a/docs/superpowers/specs/2026-05-19-xhs-netlogger-design.md
+++ b/docs/superpowers/specs/2026-05-19-xhs-netlogger-design.md
@@ -427,3 +427,221 @@ python scripts/cli.py risk-report
 - `scripts/xhs/bridge.py` — 新增 `get_netlog()` / `get_netlog_enabled()` 方法，调用 background.js 的 `get_netlog` / `get_netlog_enabled` 命令
 - `extension/background.js` — handleCommand switch 新增 `case "get_netlog"` / `case "get_netlog_enabled"`，通过 websocket bridge 路径响应（与 popup 内部 chrome.runtime.sendMessage 路径独立）
 
+---
+
+## 附录：XHS 反爬体系深度反推（2026-05-19 实施 + 冒烟）
+
+本会话端到端跑通了 search / fill-publish 两个场景，结合 netlog 实测数据反推了 XHS 完整的反自动化检测体系。
+
+### 五层防护架构
+
+```
+┌─ 第 5 层：服务端规则引擎 ────────────┐  ML + 规则混合 → isRiskUser 输出
+│  (XHS 自家 + 阿里云风控 SaaS)        │  pass / risk / limit / block
+├─ 第 4 层：行为埋点 t2/collect ───────┤  protobuf，每操作 1-10 条
+│  (XHS 自家 nameTracker=wapT)         │  操作标签 + 时序 + 上下文
+├─ 第 3 层：远程脚本 sec/v1/scripting ─┤  动态下发 JS 在浏览器执行
+│  (callFrom=web/creator-platform)     │  采集 mouse/keyboard/检测自动化
+├─ 第 2 层：Shield SDK webprofile ─────┤  浏览器/设备指纹加密上报
+│  (sdkVersion 4.3.5, profileData hex) │  navigator/canvas/webgl/audio
+└─ 第 1 层：WAF 边缘 acw_tc ───────────┘  IP/UA 信誉 + 频率
+   (阿里云)                              跨子域统一会话追踪
+```
+
+### 关键检测维度（按重要性）
+
+#### 1. 服务端风控判定 `isRiskUser`（最具利用价值）
+
+每个业务 API 调用后，前端 SDK 将服务端的风控判定主动回传到 APM：
+
+```json
+POST apm-fe.xiaohongshu.com/api/data
+[{
+  "measurement_name": "httpRequestTiming",
+  "measurement_data": {
+    "matchedPath": "/api/sns/web/v1/search/onebox",
+    "isRiskUser": "pass",               ← 服务端判定: pass / risk / limit / block
+    "isRiskReason": "[]",                ← 触发的规则数组
+    "i12": 16, "i13": 32, "i14": 100,    ← 多维评分（命名混淆）
+    "traceId": "cf2041020f9322b15...",
+    "status": 200, ...
+  }
+}]
+```
+
+**反推**：`i12/i13/i14` 是 0-100 的评分维度（推测：行为序列分 / 指纹分 / 网络环境分）。实测 `unread_count` 这种高频轮询接口 i14=62（中位），普通业务 API i14=100（满分），创作中心 i14=85。
+
+**实战利用**：自动化操作过程中实时读 `isRiskUser`，从 `pass` 变其他状态立即停手。
+
+#### 2. 浏览器指纹 Shield SDK 4.3.5
+
+```json
+POST as.xiaohongshu.com/api/sec/v1/shield/webprofile
+{
+  "platform": "Windows",
+  "sdkVersion": "4.3.5",        ← XHS Shield SDK 版本（可追踪迭代）
+  "svn": "2",
+  "profileData": "c058828ff..."  ← 加密 hex 串（含 navigator/canvas/webgl/audio/字体）
+}
+```
+
+#### 3. 远程下发脚本 `/api/sec/v1/scripting`（JSONP 模式）
+
+```json
+POST /api/sec/v1/scripting
+{ "callFrom": "web", "callback": "seccallback" }            ← 主站
+{ "callFrom": "creator-platform", "type": "ds", "appId": "ugc" }  ← 创作中心
+```
+
+—— 服务端动态下发 JS 在浏览器本地执行，采集 mouse/keyboard timing + 检测 webdriver/Puppeteer 痕迹。`callFrom` 按场景下发不同检测脚本。
+
+#### 4. 行为采集 `t2.xiaohongshu.com/api/v2/collect`
+
+protobuf binary 编码（base64），每个用户操作 1-10 条。明文可见：
+- artifact: `xhs-pc-web` 6.11.1
+- app: `discovery-undefined` / `ugc`（创作中心）
+- device_id: `febeb55be25f2a4093229f58643bd140`（32 字符 hex，跨上报一致）
+- user_id, session UUIDs, UA
+- **中文操作标签**：`创作者-新发布视频题` / `创作者服务平台` / `official`
+
+#### 5. APM 行为埋点 `apm-fe.xiaohongshu.com/api/data` (wapT SDK)
+
+JSON 明文，每个 API 调用一条 timing 记录，含：
+- `context_sdkSessionId / pageSessionId / sdkSeqId`（**单调递增**，跳号即异常）
+- `context_deviceId`（与 t2 一致）
+- `context_route`（完整页面路由）
+- `context_artifactName: "xhs-pc-web"`
+- `measurement_name: "httpRequestTiming"` 含 `isRiskUser`（见 #1）
+
+#### 6. 业务 API 签名 `x-s-common`
+
+实测 25/27 业务 API 带 `x-s-common` header。**旧 spec 假设的 `xs / xt` 双签名已废弃**（实测 0 命中）。XHS 演进为 `x-s-common` 单签名方案。
+
+主站签名覆盖率 92%，创作中心 60%（大量 OPTIONS preflight 无签名）。
+
+#### 7. Cookie 一致性追踪
+
+| Cookie | 用途 |
+|---|---|
+| `a1`（设备指纹种子） | 100% 命中，device_id 派生自 |
+| `web_session` | 主站登录态 |
+| `webId` / `gid` | 浏览器 ID / 设备识别 |
+| `acw_tc`（阿里云 WAF）| **跨子域统一指纹**，每次跨子域跳转重新颁发，强一致追踪 |
+| `tgw_l7_route`（阿里云 SLB）| ros-upload 每次 PUT 都换路由 cookie，防 hash 缓存攻击 |
+| CAS SSO 链 5 cookie | 创作中心独立 session（见 #9） |
+
+#### 8. ros-upload 上传链路
+
+```
+1. GET creator/api/media/v1/upload/creator/permit?biz_name=spectrum&scene=image
+   响应: { code:0, data: { uploadTempPermits, result } }  ← 预签名 URL
+2. OPTIONS ros-upload.xiaohongshu.com/?speedTestToken=xxx  ← CDN 选优
+3. PUT ros-upload.xiaohongshu.com/spectrum/<obj_key>       ← binary 上传
+```
+
+`biz_name=spectrum` 是 XHS 内部图片处理服务 / OSS bucket 代号。
+
+#### 9. 创作中心 CAS SSO 鉴权链
+
+创作中心**独立于主站 session**，必须经过 CAS 拿单独的 creator session：
+
+```
+1. /publish/publish → 401（无 creator session）
+2. → /login?redirectReason=401 重定向
+3. → customer.xiaohongshu.com/api/cas/customer/web/zones
+4. → customer.xiaohongshu.com/api/cas/customer/web/service-ticket
+5. → 5 cookie：customer-sso-sid / x-user-id-creator.xiaohongshu.com /
+       access-token-creator.xiaohongshu.com / galaxy_creator_session_id /
+       galaxy.creator.beaker.session.id
+6. → /publish/publish 带 creator session 重试
+```
+
+#### 10. A/B 测试 + 检测规则分层 `racing_get/report`
+
+```json
+POST edith.xiaohongshu.com/api/sns/web/racing_get
+POST edith.xiaohongshu.com/api/sns/web/racing_report
+{
+  "racing_info": [
+    { "web_id": "febeb55b...", "domain": "web_ab" },     ← 设备级 A/B
+    { "user_id": "6919c59d...", "domain": "web_user" }    ← 用户级 A/B
+  ],
+  "source": "web",
+  "app": "creator-publish"
+}
+```
+
+XHS 给不同用户分配不同检测规则版本（A/B 分流）。同一段自动化代码对不同账号可能效果不同。
+
+### 🚨 反爬陷阱：Honey Pot Tab（实施时新发现）
+
+XHS 创作中心给每个 tab 放**真+假**两份：
+
+```html
+<!-- 真 tab：Vue scoped，无 hp 标记，藏在 -9999px 但 pointer-events: auto -->
+<div data-v-1ff40f7c data-v-0b179352 class="creator-tab"
+     style="position: absolute; left: -9999px; top: -9999px;">
+  <span class="title">上传图文</span>
+</div>
+
+<!-- 假 tab (honey pot)：data-hp-kind + button-hp-installed，opacity:1e-05 -->
+<div class="creator-tab" button-hp-installed="1"
+     data-hp-kind="creator-tab-上传图文" aria-hidden="true"
+     style="position: absolute; opacity: 1e-05; pointer-events: auto;">
+</div>
+```
+
+**点击 honey pot 会被标记为机器人 + active class 静默不切换**。正确策略：排除任何带 `data-hp-kind` 或 `button-hp-installed` 属性的元素，只点真 Vue tab。
+
+**`active` class 会故意放在 honey pot 上反向迷惑机器人**（让你以为切换失败）。实际页面已切换，后续 selector 都能工作。
+
+### 反爬规避总策略（给自动化 / Claude）
+
+| 维度 | 风险 | 规避策略 |
+|---|---|---|
+| `isRiskUser` APM 字段 | 🔥极高（也是机会） | 主动监听：从业务 API 响应间接通过 APM 读取，pass→其他立即停手 |
+| Shield profileData | 🔥极高 | 用真实浏览器，禁止覆盖 navigator/screen/canvas/webgl |
+| `scripting` 远程脚本 | 🔥极高 | 让其正常下发执行，不要 hook 全局 `seccallback` 函数 |
+| **Honey pot tab 陷阱** | 🔥高 | 排除 `data-hp-kind` / `button-hp-installed` 元素 |
+| device_id 一致性 | 🔥高 | 不清 a1 cookie，不切 device_id |
+| 鼠标轨迹 / 键盘节奏 | 高 | Bezier 曲线 mouse move + 字符间随机 50-150ms + 0.5% 概率打错-删-重打 |
+| 操作时序 | 高 | 每个 action 间 N(2.5s, 0.8s) 高斯停顿；偶尔 5-10s 长停顿模拟"看一下" |
+| t2 protobuf 埋点 | 中 | 不屏蔽（缺失反而异常），节奏自然 |
+| `acw_tc` 跨域 | 中 | 不阻止 Set-Cookie，让 WAF 跟踪正常 |
+| CAS SSO（创作中心）| 中 | 必须走完 CAS 拿 creator session 5-cookie 链 |
+| racing A/B 分流 | 低 | 让其正常执行；保持账号年龄/行为画像 |
+
+### Response.prototype hook 必要性
+
+XHS 主 bundle 加载时用混淆代码（`_garp_xxx`）覆盖 `window.fetch`，绕过我们 `document_start` 装的 fetch hook。**Response.prototype.text/.json 是不可绕过的 hook 点**：任何代码读响应体必须调这两个方法之一。
+
+实施细节：interceptor.js 在 IIFE 顶部 capture `Response.prototype.text/.json` 引用，替换为我们的版本，原方法被调用时 postMessage 上报响应体。
+
+### 实施期间发现的 Bug 修复
+
+| 类型 | 修复 |
+|---|---|
+| **interceptor.js syntax error** | 4 处中文字符串嵌套未转义双引号（line 100/194/214/480），导致**整个 interceptor.js 从未成功 parse**。修：内部 `""` 改为中文「」 |
+| **状态同步链路竞态** | interceptor 等 content.js postMessage 启用状态期间所有 fetch 被跳过。修：interceptor 总是上报，background `netlogIngestInterceptor` 单点过滤 |
+| **URL 匹配 protocol-relative** | edith 业务 API 用 `//edith...` 协议相对 URL，与 webRequest 的绝对 URL 不等。修：`_netlogUrlMatch` 加 base URL 兼容 |
+| **fetch wrapper 覆盖** | XHS `_garp_xxx` 直接覆盖 `window.fetch`。修：改 hook Response.prototype |
+| **publish.py honey pot 陷阱** | 旧 selector 点了 `data-hp-kind` 假 tab。修：排除 hp 属性 + 等 active 切换确认 |
+| **REQBODY_MAX 2KB 截断** | APM 上报含 isRiskUser 的 JSON 1-3KB，2048 字节截断导致 JSON parse 失败。修：增大到 8192 |
+| **risk_analyzer regex 容错** | reqBody 仍可能截断时 JSON parse 失败。修：正则提取 isRiskUser/isRiskReason/i12-i14，不依赖完整 JSON |
+
+### 已知限制 / 未来改进
+
+- 账号切换不自动 clear netlog（用户需手动清空）
+- 跨域风控上报域响应体看不到（webRequest 限制 + 跨域无 interceptor）
+- 同一 url 短时间高并发请求时关联可能漏配（2s 时间窗 + url 模糊匹配）
+- `publish.py` 中 `_wait_for_upload_complete` 也可能命中类似 honey pot（待用户实测确认）
+- 当前账号已建立信任画像，所有实测 isRiskUser 均为 `pass`。要实测 `risk/limit/block` 需要：① 高频机械操作触发降评分，或 ② 在新账号上测试
+
+### 端到端冒烟实测结果
+
+| 场景 | total | isRiskUser | acw_tc 变更 | x-s-common 覆盖 | 主要 host |
+|---|---|---|---|---|---|
+| 浏览/搜索 (search "claude") | 146 | 全 pass (40/40) | 1 | 92% | t2(64) edith(27) apm-fe(25) |
+| 搜索 "ai" | 99 | 全 pass (27/27) | 0 | - | apm-fe(28) t2(28) edith(14) |
+| **创作中心填表** | 284 | 全 pass (7/7) | 1 | 60% | apm-fe(108) t2(71) as(19) edith(19) creator(16) ros-upload(3) |
+

--- a/docs/superpowers/specs/2026-05-19-xhs-netlogger-design.md
+++ b/docs/superpowers/specs/2026-05-19-xhs-netlogger-design.md
@@ -13,12 +13,11 @@
 ### 目标
 
 - 在 xiaohongshu.com 业务域 + 风控上报域采集足够信息，识别 XHS 服务端用来判定自动化的信号（cookie / header / 请求体指纹 / 响应错误码 / Set-Cookie 变化）。
-- 数据只在扩展 popup 内消费，不暴露 CLI。
+- 数据在扩展 popup 内消费，同时通过 CLI 命令 `get-netlog` / `risk-report` 暴露给 LLM/Claude，让自动化操作过程中能主动判断风控状态。
 - 隐藏入口：默认对普通使用零感知，通过彩蛋（标题连点 5 次）激活。
 
 ### 非目标
 
-- 不做 CLI 命令暴露 `get-netlog / export-netlog`（用户明确不需要）。
 - 不做跨会话 diff、两会话对比（方案 C，本期延后）。
 - 不做风控域名的自定义配置 UI（本期 hardcode）。
 - 不做自动化测试（浏览器扩展 + 真实 XHS 域难离线复现）。
@@ -354,4 +353,77 @@ content-type, server, x-application-context
 - 没看到 sentry / aegis 等第三方 —— XHS 用自家 apm-fe，未外接
 
 如果后续遇到 netlog 漏抓某些请求，回头检查 host_permissions 是否需要扩展。
+
+---
+
+## CLI 风控接口
+
+**背景**：Task 8 冒烟实测发现 XHS 检测维度的核心规律后，决定将 netlog 数据通过 CLI 暴露给 LLM/Claude，让自动化操作过程中能主动读取风控结论，替代此前"只在 popup 内消费"的决定。
+
+### 命令
+
+#### `get-netlog [--limit N]`
+
+从扩展获取当前会话的 NetLog 原始 entries（最多 500 条环形缓冲）。
+
+```bash
+python scripts/cli.py get-netlog
+python scripts/cli.py get-netlog --limit 50
+```
+
+输出格式：
+
+```json
+{
+  "total": 123,
+  "entries": [ /* NetLogEntry[] */ ]
+}
+```
+
+未启用 netlogger 时：exit code 2 + 中文提示用户去 popup 彩蛋激活。
+
+#### `risk-report`
+
+调用 `scripts/xhs/risk_analyzer.py` 的 `analyze()` 函数，基于 netlog entries 反推检测维度并给出结构化风控结论。
+
+```bash
+python scripts/cli.py risk-report
+```
+
+输出格式：
+
+```json
+{
+  "risk_level": "safe | low | medium | high | unknown",
+  "total_requests": 123,
+  "summary": "本会话采集 123 条请求，指纹上报 2 次，行为埋点 54 次。",
+  "detection_axes": {
+    "browser_fingerprint": { "endpoint": "/api/sec/v1/shield/webprofile", "called_count": 2, ... },
+    "behavior_tracking": { "endpoint": "/api/v2/collect", "called_count": 54, ... },
+    "apm_monitoring": { ... },
+    "request_signature": { "scheme": "x-s-common (current)", "coverage_pct": 92.6, ... },
+    "cookie_state": { "has_a1": true, "has_web_session": true, ... }
+  },
+  "category_distribution": { "business_api": 60, "fingerprint_upload": 12, ... },
+  "top_hosts": { "edith.xiaohongshu.com": 60, ... },
+  "high_risk_signals": [],
+  "warnings": []
+}
+```
+
+### 风险等级判断规则
+
+| risk_level | 触发条件 |
+|---|---|
+| `high` | 存在 `signature_failure` 类别请求，或 HTTP 999 响应 |
+| `medium` | HTTP 401 / 403 / 461，或 `acw_tc` cookie 变更，或 `risk_redirect` |
+| `low` | 有 warnings（签名覆盖率不足、行为埋点缺失等） |
+| `safe` | 无高风险信号、无 warnings |
+| `unknown` | netlog 为空 |
+
+### 实现细节
+
+- `scripts/xhs/risk_analyzer.py` — 纯函数 `analyze(entries)` 模块，无副作用，可独立单测
+- `scripts/xhs/bridge.py` — 新增 `get_netlog()` / `get_netlog_enabled()` 方法，调用 background.js 的 `get_netlog` / `get_netlog_enabled` 命令
+- `extension/background.js` — handleCommand switch 新增 `case "get_netlog"` / `case "get_netlog_enabled"`，通过 websocket bridge 路径响应（与 popup 内部 chrome.runtime.sendMessage 路径独立）
 

--- a/docs/superpowers/specs/2026-05-19-xhs-netlogger-design.md
+++ b/docs/superpowers/specs/2026-05-19-xhs-netlogger-design.md
@@ -318,3 +318,40 @@ content-type, server, x-application-context
 - 修改后的 `extension/{netlogger.js, background.js, interceptor.js, popup.html, popup.js, manifest.json}`
 - 本设计文档
 - 后续 brainstorming 出来的 implementation plan（spec 批准后由 writing-plans 产出）
+
+---
+
+## 附录：风控/上报域名调研（2026-05-19）
+
+通过 `performance.getEntriesByType('resource')` 在 xiaohongshu.com 上抓到的跨域 host 清单（首页 + 搜索 + 笔记详情 浏览 ~1min）：
+
+| Host | 用途推断 | 是否监听 |
+|---|---|---|
+| `apm-fe.xiaohongshu.com` | 前端 APM 监控（性能/错误/风控数据上报） | ✓ |
+| `as.xiaohongshu.com` | 应用统计 / 事件上报 | ✓ |
+| `edith.xiaohongshu.com` | XHS 主业务 API（含 /api/sns/web/...） | ✓ |
+| `t2.xiaohongshu.com` | tracking 上报 | ✓ |
+| `picasso-static.xiaohongshu.com` | 静态资源（图片处理服务） | ✓（业务域内，顺便监听） |
+| `www.xiaohongshu.com` / `xiaohongshu.com` / `creator.xiaohongshu.com` | 业务页面 + API | ✓ |
+| `sns-avatar-qc.xhscdn.com` / `sns-na-i2.xhscdn.com` / `sns-webpic-qc.xhscdn.com` | 图片 CDN | ✗（静态资源，过滤掉） |
+
+**固化的 `host_permissions`：**
+
+```json
+"host_permissions": [
+  "https://*.xiaohongshu.com/*",
+  "https://xiaohongshu.com/*",
+  "ws://localhost/*"
+]
+```
+
+一行通配 `*.xiaohongshu.com` 覆盖所有当前 + 未来 XHS 子域。`xhscdn.com` 不加（图片资源 / NETLOG_SKIP_TYPES 已过滤）。
+
+**调研未发现的潜在域名：**
+
+- 没看到 `fp.xiaohongshu.com`（指纹）—— 可能用 a1 cookie 派生 + edith 内嵌而非独立子域
+- 没看到 `sec.xiaohongshu.com`（安全）—— 同上
+- 没看到 sentry / aegis 等第三方 —— XHS 用自家 apm-fe，未外接
+
+如果后续遇到 netlog 漏抓某些请求，回头检查 host_permissions 是否需要扩展。
+

--- a/docs/superpowers/specs/2026-05-19-xhs-netlogger-design.md
+++ b/docs/superpowers/specs/2026-05-19-xhs-netlogger-design.md
@@ -1,0 +1,320 @@
+# XHS NetLogger 设计文档
+
+**日期**：2026-05-19
+**分支**：feat/extension-bridge
+**目标**：在浏览器扩展中加入小红书网页版网络监听能力，反向推导 XHS 用于检测自动化的"维度"，让插件 / Claude 操作时能规避风控。
+
+参考实现：`D:\OSS\BHP_Production\BHP\modules\net-logger.js`（BOSS 直聘网页版的 webRequest 全量监听器）。
+
+---
+
+## 目标与非目标
+
+### 目标
+
+- 在 xiaohongshu.com 业务域 + 风控上报域采集足够信息，识别 XHS 服务端用来判定自动化的信号（cookie / header / 请求体指纹 / 响应错误码 / Set-Cookie 变化）。
+- 数据只在扩展 popup 内消费，不暴露 CLI。
+- 隐藏入口：默认对普通使用零感知，通过彩蛋（标题连点 5 次）激活。
+
+### 非目标
+
+- 不做 CLI 命令暴露 `get-netlog / export-netlog`（用户明确不需要）。
+- 不做跨会话 diff、两会话对比（方案 C，本期延后）。
+- 不做风控域名的自定义配置 UI（本期 hardcode）。
+- 不做自动化测试（浏览器扩展 + 真实 XHS 域难离线复现）。
+- 不替换现有 404 诊断（interceptor.js 现有逻辑）或 302 观测（background.js webRequest 现有逻辑），netlogger 是新增的独立 listener。
+
+---
+
+## 选定方案
+
+**方案 B：webRequest 全量 + fetch/XHR hook 融合。**
+
+- `chrome.webRequest` 4 阶段监听拿外层 HTTP 信号 + 请求体（指纹上报的关键载荷）
+- `interceptor.js` 在 xiaohongshu.com 域 MAIN world hook fetch/XHR 拿响应体 + 应用层 header
+- 按 `(method, url, 2s 时间窗)` 模糊关联两侧记录，合并为一条
+- popup 面板「时序流」 + 「检测维度」双 tab
+
+排除方案 A（webRequest only，看不到响应体与签名细节）与方案 C（B + 会话对比，工作量太大且 ROI 不确定，先把 B 做扎实）。
+
+---
+
+## 组件结构
+
+| 文件 | 状态 | 职责 |
+|---|---|---|
+| `extension/netlogger.js` | 新建 | webRequest 4 阶段监听 + 环形缓冲 + storage 持久化 |
+| `extension/interceptor.js` | 扩充 | 现有 404 诊断保留；新增"启用 netlog 时"记录全量 fetch/XHR 响应体 + 应用层 header |
+| `extension/background.js` | 扩充 | importScripts netlogger.js；接 interceptor 上来的响应体信号；按 url+ts 关联 |
+| `extension/popup.html` / `popup.js` | 扩充 | NetLog 卡片（彩蛋激活后显示）+ 时序流 / 检测维度 双 tab |
+| `extension/manifest.json` | 扩充 | host_permissions 加风控上报域 |
+
+## 数据流
+
+```
+用户请求
+  │
+  ├─→ chrome.webRequest (netlogger.js, background)
+  │     ① onBeforeRequest        → method/url/reqBody bytes
+  │     ② onSendHeaders          → 最终请求头（含 cookie/xs/xt/sec-fetch-*)
+  │     ③ onHeadersReceived      → status/respHeaders/set-cookie
+  │     ④ onCompleted/Error      → 耗时、错误码
+  │
+  └─→ interceptor.js (MAIN world, 仅 xiaohongshu.com)
+        fetch/XHR hook → 响应体 + 应用层 header
+        postMessage → content.js → background → netlogger
+        ↓ 按 (method+url+时间窗) 模糊关联
+
+netlogger 环形缓冲 (500 条)
+  │
+  ├─→ 每 10 条 / 关键事件触发写入
+  │   chrome.storage.local.netLog
+  │
+  └─→ popup 拉取 + chrome.runtime push 实时增量
+```
+
+---
+
+## 关键设计点
+
+### A. 启用开关 / 彩蛋激活
+
+- `chrome.storage.local.netlogEnabled`（boolean）作为持久化开关
+- popup 顶部标题 "XHS Bridge" 连点 5 次切换；500ms 内无点击则计数器重置
+- 激活后下方多出一张 "NetLog" 卡片
+- 未启用时 netlogger / interceptor 的全部监听器 early return，零开销
+- 已激活时再连点 5 次触发确认对话框，确认后关闭
+
+### B. interceptor ↔ netlogger 关联
+
+- 业务域内 interceptor 拿到响应后，按 `(method, url, 最近 2s 内的 webRequest 记录)` 关联回填响应体
+- 关联失败的 interceptor 记录独立存入，标记 `_orphan: true`
+- 跨域上报（fp / sentry / aegis 等）只走 webRequest 路径，不要求关联响应体
+
+### C. 检测维度自动分类（启发式）
+
+| category | 判定条件 |
+|---|---|
+| `fingerprint_upload` | host 含 fp / sec / aegis / sentry / track 关键字 OR 请求体含 webdriver / navigator / screen / timezone 字段 |
+| `business_error` | status ∈ {401, 403, 461, 999} OR (HTTP 200 + 前端渲染 404) |
+| `risk_redirect` | 302 → /404 或 /login |
+| `signature_failure` | 302 Location 含 error_code=300031 / 300032 / 300033 |
+| `cookie_change` | Set-Cookie 中新键 / 值变更（与上一条同 host 记录比较） |
+| `business_api` | 路径含 /api/ 且 status=2xx |
+| `page_nav` | resourceType=main_frame |
+| `other` | 其他 |
+
+一条 entry 可命中多个 signal（写入 `signals: string[]`），但 `category` 只取主分类（按上表自上而下的优先级）。
+
+### D. 性能与容量
+
+- 环形缓冲 500 条上限
+- 单条请求体截断 2KB / 响应体截断 4KB
+- 静态资源（image / font / stylesheet）按 `webRequest details.type` 过滤，不入栈
+- 启用状态下预估额外开销：~5-10% CPU 在请求峰值时
+- chrome.storage.local 限额 5MB，本设计总量预估 < 3MB
+
+---
+
+## 数据 Schema
+
+```typescript
+interface NetLogEntry {
+  // ── 标识 ──
+  id: string;                  // `${ts}_${requestId}`
+  requestId: string;           // webRequest requestId
+  ts: number;                  // onBeforeRequest 时间戳 (ms)
+  tsLabel: string;             // "HH:mm:ss.SSS"
+
+  // ── HTTP 基础 ──
+  method: string;
+  url: string;
+  path: string;                // pathname + 关键 query (xsec_token=…&xsec_source=…)
+  host: string;
+  resourceType: string;        // main_frame / xhr / fetch / sub_frame
+  tabId: number;
+
+  // ── 请求（webRequest + interceptor 融合）──
+  reqHeaders: Record<string, string>;     // 仅保留关键白名单
+  reqBody: string | null;                 // 截断 2KB；raw bytes 解码或 formData JSON
+  reqFingerprint: {
+    has_xs: boolean;
+    has_xt: boolean;
+    has_xsCommon: boolean;
+    sec_fetch_site: string | null;
+    sec_fetch_mode: string | null;
+    referer: string | null;
+    origin: string | null;
+    ua_prefix: string;                     // user-agent 前 80 字符
+    cookie: {
+      has_a1: boolean;
+      has_web_session: boolean;
+      has_webId: boolean;
+      has_gid: boolean;
+      a1_preview: string | null;
+      web_session_preview: string | null;
+    };
+  };
+
+  // ── 响应 ──
+  status: number;
+  statusLine: string;          // "200 OK" / "302 Found" / …
+  respHeaders: Record<string, string>;
+  respBody: string | null;     // 截断 4KB；仅业务域（interceptor 能拿到）
+  setCookie: string[] | null;  // 解析后的 cookie 名列表
+
+  // ── 时序 ──
+  duration_ms: number;
+  err: string | null;
+
+  // ── 分析层（netlogger 计算）──
+  category: NetLogCategory;
+  signals: string[];           // 例: ["fingerprint_upload", "set_cookie_changed:sec_xxx"]
+  cookieDiff: {
+    added: string[];
+    changed: string[];
+    removed: string[];
+  } | null;
+  redirectTo: string | null;   // 302 Location
+  errorCode: string | null;    // 300031/300032/… 从 location query 解析
+
+  _orphan?: true;              // interceptor 未关联到 webRequest 时标记
+}
+
+type NetLogCategory =
+  | "fingerprint_upload"
+  | "business_error"
+  | "risk_redirect"
+  | "signature_failure"
+  | "cookie_change"
+  | "business_api"
+  | "page_nav"
+  | "other";
+```
+
+### 关键 cookie 白名单
+
+请求 cookie 字段中以下 key 会被记录到 `reqFingerprint.cookie`：
+
+- `a1`（设备指纹种子）
+- `web_session`（登录态）
+- `webId`
+- `gid`
+- 其他不在白名单的 cookie 名记入 `signals` 但值不存
+
+### 关键 header 白名单（reqHeaders）
+
+```
+xs, xt, x-s-common, x-t, x-mns-platform,
+sec-fetch-site, sec-fetch-mode, sec-fetch-dest, sec-fetch-user,
+referer, origin, user-agent,
+content-type, accept, accept-language
+```
+
+### 响应 header 白名单（respHeaders）
+
+```
+location, set-cookie, cache-control, x-request-id,
+content-type, server, x-application-context
+```
+
+---
+
+## popup NetLog 面板（草图）
+
+```
+┌─ XHS Bridge ───────────────────────┐
+│ [logo] XHS Bridge       ● connected│  ← 标题连点 5 次激活
+├────────────────────────────────────┤
+│ 已连接到 bridge server             │
+│ 当前账号：xxx                       │
+│ [打开小红书]  [退出登录]            │
+├────────────────────────────────────┤
+│ ▼ NetLog  [enabled] [clear] [⬇json]│  ← 激活后显示
+│ ┌──────────────────────────────┐   │
+│ │[ 时序流 ] [ 检测维度 ]        │   │
+│ ├──────────────────────────────┤   │
+│ │ 时序流：                       │   │
+│ │ 18:42:11.245 GET /api/sns/web/v1/feed  200 142ms [API]            │
+│ │ 18:42:11.512 POST fp.snssdk.com/v1/fp  200 88ms  [指纹↑] ★       │
+│ │ 18:42:12.103 GET /explore/abc?xsec_…   302 41ms  [风控跳转] ★    │
+│ │ 18:42:12.180 GET /404?error_code=…     200 120ms [API]            │
+│ │ …                                                                  │
+│ ├──────────────────────────────┤   │
+│ │ 检测维度（点击展开详情）：     │   │
+│ │ ▾ 指纹上报 (12)                │   │
+│ │   fp.snssdk.com/v1/fp  ×8 [body 含 webdriver/screen/…]           │
+│ │   sec.xiaohongshu.com  ×4                                         │
+│ │ ▾ 签名失败 (3)                 │   │
+│ │   error_code=300033  token 与 session/IP 不匹配                  │
+│ │ ▾ Cookie 变化 (5)              │   │
+│ │   sec_xxx 新增（响应来自 /api/.../init）→ 风控触发标记           │
+│ │ ▾ 业务错误 (2) / 风控跳转 (1)  │   │
+│ └──────────────────────────────┘   │
+└────────────────────────────────────┘
+```
+
+- 行点击展开看完整 entry（折叠 JSON 视图）
+- `★` 标记需要重点关注的（指纹上报 / 风控跳转）
+- "⬇json" 按钮把当前缓冲全量导出为 JSON 文件下载
+
+---
+
+## 错误处理与边缘情况
+
+| 场景 | 处理 |
+|---|---|
+| webRequest 拿不到 reqBody（POST + 二进制） | `reqBody: "[binary]"`，只记字节数 |
+| interceptor 跨标签页污染 | content.js 校验 sender.tab.id 与 background 记录的 tabId 匹配 |
+| popup 关闭再开时数据丢失 | 数据存在 chrome.storage.local，popup 重新拉即可 |
+| storage 写满（5MB 限制） | 环形缓冲 500 条 + 单条体积上限保证总量 < 3MB |
+| 用户切换账号（a1 变化） | 触发自动 clear，避免跨账号污染分析 |
+| 风控域名扩展 | host_permissions hardcode；本期不做配置 UI |
+| service worker 重启丢内存缓冲 | webRequest listener 在 SW 重启后重新注册；内存丢失但 storage 持久部分保留 |
+
+---
+
+## 实现顺序与工作量估算
+
+| # | 任务 | 改动文件 | 估算 | 验收 |
+|---|---|---|---|---|
+| 1 | 加风控域名到 host_permissions + 调研真实上报域名清单 | `manifest.json` | ~30 LOC | 装载扩展无错；调研结论补充到本文档 |
+| 2 | 创建 netlogger.js：4 阶段 webRequest 监听 + 环形缓冲 + storage 持久化 + 启用开关 | 新建 `extension/netlogger.js` (~300 LOC) | ~3h | 启用后能在 storage 里看到 entries；关闭后零监听器活跃 |
+| 3 | background.js 引入 netlogger + 暴露查询/清空消息接口 | `background.js` (~50 LOC) | ~30min | popup 能通过 runtime.sendMessage 拉到 log |
+| 4 | interceptor.js 扩充：启用 netlog 时记录全量 fetch/XHR 响应体 + postMessage 上报 | `interceptor.js` (~80 LOC) | ~1.5h | 业务域内能拿到响应体并关联到 netlogger entry |
+| 5 | netlogger 关联 + 分类逻辑：interceptor 信号回填 + category/signals/cookieDiff 计算 | `netlogger.js` (~150 LOC) | ~2h | 每条 entry 有正确 category；cookieDiff 能算出 Set-Cookie 变化 |
+| 6 | popup UI：彩蛋激活 + NetLog 卡片 + 时序流 tab | `popup.html / popup.js` (~250 LOC) | ~3h | 标题连点 5 次激活；时序流实时刷新；点击行展开详情 |
+| 7 | popup UI：检测维度 tab + 折叠分组 + json 导出按钮 | `popup.html / popup.js` (~150 LOC) | ~2h | 5 个分类正确归类；导出 JSON 文件可下载 |
+| 8 | 手工冒烟测试：浏览/搜索/故意触发风控/切账号 | — | ~1h | 全场景跑通；分类无误判 |
+
+**估算总量**：约 1000 LOC + 约 13h 集中工作时间。
+
+---
+
+## 主要风险与未知点
+
+1. **风控上报域名清单不确定** — 目前对 XHS 实际使用的指纹上报域名只有部分猜测（fp.snssdk.com 等字节系常见域，但 XHS 是否用同套不确定）。任务 1 包含调研：先用宽松 host_permissions 临时监听一阵，看实际有哪些跨域 POST，再固化清单。
+2. **interceptor ↔ webRequest 关联失败率** — 时间窗匹配可能漏关联（特别是高并发短连接）。先用 2s 窗 + url 完全匹配，观察漏匹配率，必要时改用 `Performance.getEntriesByName` 拿浏览器侧 timing 辅助匹配。
+3. **chrome.storage.local 跨会话恢复** — Manifest V3 SW 在用户关闭浏览器时会被销毁；storage 持久但内存缓冲来不及写入的 N 条会丢。可接受。
+4. **xs / xt 签名内部值无法拿到** — 只能拿到 fetch init.headers 里显式设置的；XHS SDK 若在更深层（如 Service Worker 拦截后注入）注入 header，fetch hook 也拿不到，需 chrome.debugger（本期不做）。
+5. **彩蛋激活的 UX** — 5 次点击前无任何视觉反馈，新装扩展用户完全不知道这功能存在 —— 这是设计目标，不算风险。
+
+---
+
+## 测试方案
+
+1. **手工冒烟**：
+   - 激活 NetLog → 打开 xiaohongshu.com → 浏览/搜索 → 检查时序流是否完整、检测维度分类是否合理
+   - 故意不带 xsec_token 直接访问 /explore/xxx → 验证抓到 `signature_failure` / `risk_redirect` 分类
+   - 切账号 → 验证自动 clear 触发
+2. **回归**：现有 `cmd_diagnose_404` / `cmd_check_risk` 不受影响（netlogger 是独立 listener，不替换原有逻辑）
+3. **性能**：开 / 不开 netlog 在 xhs 首页滚动 30s，对比 SW CPU 占用（人工观察 chrome://serviceworker-internals）
+4. 不写自动化测试
+
+---
+
+## 交付物
+
+- 修改后的 `extension/{netlogger.js, background.js, interceptor.js, popup.html, popup.js, manifest.json}`
+- 本设计文档
+- 后续 brainstorming 出来的 implementation plan（spec 批准后由 writing-plans 产出）

--- a/extension/background.js
+++ b/extension/background.js
@@ -74,12 +74,22 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   }
   if (msg.type === "NETLOG_SET_ENABLED") {
     netlogSetEnabled(msg.enabled);
+    chrome.tabs.query({ url: ["*://*.xiaohongshu.com/*"] }, (tabs) => {
+      for (const t of tabs) {
+        chrome.tabs.sendMessage(t.id, { type: "NETLOG_ENABLED_CHANGED", enabled: msg.enabled }).catch(() => {});
+      }
+    });
     sendResponse({ ok: true, enabled: netlogIsEnabled() });
     return true;
   }
   if (msg.type === "NETLOG_GET_ENABLED") {
     sendResponse({ enabled: netlogIsEnabled() });
     return true;
+  }
+
+  if (msg.type === "NETLOG_INTERCEPTOR_ENTRY") {
+    netlogIngestInterceptor(msg.payload);
+    return false;
   }
 });
 

--- a/extension/background.js
+++ b/extension/background.js
@@ -74,11 +74,6 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   }
   if (msg.type === "NETLOG_SET_ENABLED") {
     netlogSetEnabled(msg.enabled);
-    chrome.tabs.query({ url: ["*://*.xiaohongshu.com/*"] }, (tabs) => {
-      for (const t of tabs) {
-        chrome.tabs.sendMessage(t.id, { type: "NETLOG_ENABLED_CHANGED", enabled: msg.enabled }).catch(() => {});
-      }
-    });
     sendResponse({ ok: true, enabled: netlogIsEnabled() });
     return true;
   }

--- a/extension/background.js
+++ b/extension/background.js
@@ -21,6 +21,46 @@ chrome.alarms.onAlarm.addListener(() => {
 
 // ───────────────────────── WebSocket ─────────────────────────
 
+function setStatus(connected) {
+  chrome.storage.session.set({ wsConnected: connected });
+}
+
+function broadcastStatus() {
+  const status = { wsConnected: ws !== null && ws.readyState === WebSocket.OPEN };
+  chrome.runtime.sendMessage({ type: "STATUS_CHANGED", status }).catch(() => {});
+}
+
+chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
+  if (msg.type === "GET_STATUS") {
+    sendResponse({
+      success: true,
+      status: { wsConnected: ws !== null && ws.readyState === WebSocket.OPEN },
+    });
+    return true;
+  }
+
+  if (msg.type === "ANALYZE_RISK_CONTROL") {
+    cmdAnalyzeRiskControl({ probeUrls: msg.probeUrls || [] })
+      .then(report => sendResponse(report))
+      .catch(e => sendResponse({ error: String(e.message || e) }));
+    return true;
+  }
+
+  if (msg.type === "XHS_BLOCK_EVENT") {
+    storeBlockEvent(msg.event).catch(() => {});
+    // 通知 popup 实时刷新
+    chrome.runtime.sendMessage({ type: "BLOCK_EVENT_ADDED", event: msg.event }).catch(() => {});
+    return false;
+  }
+
+  if (msg.type === "GET_404_DIAGNOSTICS") {
+    chrome.storage.session.get("blockEvents", (data) => {
+      sendResponse({ events: data.blockEvents || [] });
+    });
+    return true;
+  }
+});
+
 function connect() {
   if (ws && (ws.readyState === WebSocket.CONNECTING || ws.readyState === WebSocket.OPEN)) return;
 
@@ -29,6 +69,8 @@ function connect() {
   ws.onopen = () => {
     console.log("[XHS Bridge] 已连接到 bridge server");
     ws.send(JSON.stringify({ role: "extension" }));
+    setStatus(true);
+    broadcastStatus();
   };
 
   ws.onmessage = async (event) => {
@@ -48,6 +90,8 @@ function connect() {
 
   ws.onclose = () => {
     console.log("[XHS Bridge] 连接断开，3s 后重连...");
+    setStatus(false);
+    broadcastStatus();
     setTimeout(connect, 3000);
   };
 
@@ -76,6 +120,30 @@ async function handleCommand(msg) {
     case "set_file_input":
       return await cmdSetFileInputViaDebugger(params);
 
+    case "click_element":
+    case "click_nth_element":
+    case "click_element_by_text":
+      return await cmdClickViaDebugger(method, params);
+
+    case "press_key":
+      return await cmdPressKeyViaDebugger(params);
+
+    case "type_text":
+      return await cmdTypeTextViaDebugger(params);
+
+    // ── 风控分析 ──
+    case "analyze_risk_control":
+      return await cmdAnalyzeRiskControl(params);
+
+    case "get_404_diagnostics": {
+      const data = await chrome.storage.session.get("blockEvents");
+      return data.blockEvents || [];
+    }
+
+    case "clear_404_diagnostics":
+      await chrome.storage.session.set({ blockEvents: [] });
+      return null;
+
     // ── Cookies ──
     case "get_cookies":
       return await cmdGetCookies(params);
@@ -91,6 +159,8 @@ async function handleCommand(msg) {
     case "get_scroll_top":
     case "get_viewport_height":
     case "get_url":
+    case "get_elements_info":
+    case "get_iframe_text":
       return await cmdEvaluateInMainWorld(method, params);
 
     // ── DOM 操作（在页面 MAIN world 执行，无需 content script 就绪） ──
@@ -101,10 +171,421 @@ async function handleCommand(msg) {
 
 // ───────────────────────── 导航 ─────────────────────────
 
-async function cmdNavigate({ url }) {
+/**
+ * 导航完成后立即在 MAIN world 检测页面是否为 404 / 风控拦截页。
+ * 这是捕获导航级 404 的唯一可靠时机（fetch/XHR 拦截器看不到 browser navigation）。
+ */
+async function detectNavigationBlock(tabId, navigatedUrl, finalUrl) {
+  const results = await chrome.scripting.executeScript({
+    target: { tabId },
+    world: "MAIN",
+    func: (targetUrl, landedUrl) => {
+      // ── 1. 读 cookie 快照 ──────────────────────────────────
+      const cookieMap = {};
+      for (const p of document.cookie.split(";")) {
+        const i = p.indexOf("=");
+        if (i < 0) continue;
+        cookieMap[p.slice(0, i).trim()] = p.slice(i + 1).trim();
+      }
+      const cookies = {
+        has_a1:          "a1" in cookieMap,
+        has_web_session: "web_session" in cookieMap,
+        has_webId:       "webId" in cookieMap,
+        a1_preview:          cookieMap["a1"]          ? cookieMap["a1"].slice(0, 12)          + "…" : null,
+        web_session_preview: cookieMap["web_session"] ? cookieMap["web_session"].slice(0, 10) + "…" : null,
+      };
+
+      // ── 2. 解析 xsec_token（从原始目标 URL）────────────────
+      let xsecToken = null, xsecSource = null;
+      try {
+        const u = new URL(targetUrl);
+        xsecToken  = u.searchParams.get("xsec_token");
+        xsecSource = u.searchParams.get("xsec_source");
+      } catch (_) {}
+
+      // ── 3. 判断是否为 404 / 风控拦截页 ───────────────────
+
+      // 优先：检查最终落地 URL 是否为 /404 重定向（最可靠的信号）
+      let blockType = null;
+      let httpLike404 = false;
+      let redirectSource = null;
+
+      if (landedUrl && /xiaohongshu\.com\/404(\?|$)/.test(landedUrl)) {
+        blockType = "redirect_404";
+        httpLike404 = true;
+        try {
+          redirectSource = new URL(landedUrl).searchParams.get("source") || null;
+        } catch (_) {}
+      }
+
+      // 备选：页面 title 含 404
+      if (!blockType) {
+        const title = document.title || "";
+        if (title.includes("404") || title.includes("Not Found")) {
+          blockType = "http_404";
+          httpLike404 = true;
+        }
+      }
+
+      // SPA 渲染的 404（HTTP 200 但内容不存在）
+      // 特征：__INITIAL_STATE__ 有错误标记，或特定 DOM 元素存在
+      if (!blockType) {
+        try {
+          const s = window.__INITIAL_STATE__;
+          if (s) {
+            if (s.pageError || s.errorCode || s.forbidden || s.noteError) {
+              blockType = "spa_404";
+            }
+            // 笔记详情页：note 对象存在但 status 为下架/删除
+            const note = s?.note?.noteDetailMap
+              ? Object.values(s.note.noteDetailMap)[0]?.note
+              : null;
+            if (note && (note.status === "banned" || note.status === "deleted" || note.status === "invisible")) {
+              blockType = "content_removed";
+            }
+          }
+        } catch (_) {}
+      }
+
+      // DOM 指纹检测
+      if (!blockType) {
+        const notFoundEl =
+          document.querySelector('[class*="not-found"]') ||
+          document.querySelector('[class*="error-page"]') ||
+          document.querySelector('[class*="page-404"]');
+        if (notFoundEl) blockType = "spa_404";
+      }
+
+      // 风控验证弹窗（不是 404，但也要记录）
+      if (!blockType) {
+        const captchaEl =
+          document.querySelector('[class*="captcha"]') ||
+          document.querySelector('[class*="verify"]') ||
+          document.querySelector("#captcha-container");
+        if (captchaEl) blockType = "captcha_block";
+      }
+
+      if (!blockType) return null;  // 正常页面，不记录
+
+      // ── 4. 根因分析 ──────────────────────────────────────
+      let diagnosis;
+      const isPage = !/\/api\//.test(targetUrl);
+
+      if (blockType === "redirect_404") {
+        // /404?source= 是 XHS 302 重定向风控的标准形式，根因最确定
+        if (!cookies.has_web_session) {
+          diagnosis = {
+            root_cause: "未登录 / web_session 失效，服务端 302 重定向到 /404",
+            cause_category: "session",
+            detail:
+              `XHS 服务端检测到请求无有效 session，执行 302 重定向到 /404?source=${redirectSource || targetUrl}。\n` +
+              "web_session cookie 不存在或已过期，xsec_token 随之失效。\n" +
+              "解决：重新登录获取新的 web_session。",
+            confidence: "high",
+            how_xhs_decides:
+              "服务端在路由层校验 web_session 有效性，失效时直接 302 到 /404，" +
+              "source 参数记录原始请求路径供前端展示。",
+          };
+        } else if (!xsecToken) {
+          diagnosis = {
+            root_cause: "xsec_token 缺失，服务端 302 重定向到 /404",
+            cause_category: "token",
+            detail:
+              `原始路径 ${redirectSource || targetUrl} 未携带 xsec_token，服务端立即 302 到 /404。\n` +
+              "必须从搜索 / 推荐流获取包含 xsec_token 的完整 URL，不能直接构造。",
+            confidence: "high",
+            how_xhs_decides:
+              "CDN / 路由层在 URL 路由前校验 xsec_token 存在性，缺失则 302 到 /404，" +
+              "早于业务逻辑执行，source 参数为原始路径。",
+          };
+        } else {
+          diagnosis = {
+            root_cause: `xsec_token 绑定验证失败，服务端 302 重定向到 /404（来源: ${xsecSource || "未知"}）`,
+            cause_category: "token",
+            detail:
+              `token 和 session 均存在，但服务端解密 xsec_token 后验证失败，302 到 /404?source=${redirectSource || targetUrl}。\n` +
+              "可能原因：\n" +
+              "  1. xsec_token 超过有效期（通常数小时）\n" +
+              "  2. IP 变化导致 token 中的 ipHash 不匹配\n" +
+              `  3. xsec_source="${xsecSource}" 来源类型与当前访问场景不符\n` +
+              "  4. token 从其他账号获取（token 绑定颁发时的 userId）",
+            confidence: "high",
+            how_xhs_decides:
+              "服务端解密 xsec_token：{noteId, userId, ipHash, ts, source}，逐字段比对当前请求，" +
+              "任一不符则 302 到 /404，source 参数为被拒绝的原始路径。",
+          };
+        }
+      } else if (blockType === "captcha_block") {
+        diagnosis = {
+          root_cause: "触发人机验证（验证码弹窗）",
+          cause_category: "captcha",
+          detail:
+            "页面弹出验证码，通常由短时间内大量请求或异常行为模式触发。" +
+            "XHS 的风控系统在请求频率 / 行为评分超阈值时插入验证流程而非直接封禁。",
+          confidence: "high",
+          how_xhs_decides:
+            "服务端对 {IP, userId} 维护请求频率计数，超过阈值时在响应中注入验证码触发标记，" +
+            "前端 JS 检测到标记后渲染验证码组件。",
+        };
+      } else if (!xsecToken && isPage) {
+        diagnosis = {
+          root_cause: "xsec_token 缺失——直接导航到笔记 URL",
+          cause_category: "token",
+          detail:
+            "URL 不含 xsec_token 参数，服务端返回 404（故意用 404 而非 403 迷惑爬虫）。\n" +
+            "正确做法：必须从搜索 / 推荐流获取含 xsec_token 的完整 URL。",
+          confidence: "high",
+          how_xhs_decides:
+            "CDN / API 网关在路由层校验 xsec_token 存在性，缺失直接短路返回 404。",
+        };
+      } else if (!cookies.has_web_session && isPage) {
+        diagnosis = {
+          root_cause: "web_session 失效（未登录），token 同步失效",
+          cause_category: "session",
+          detail:
+            "xsec_token 存在但 web_session cookie 已失效。" +
+            "服务端将 token 与颁发时的 session 绑定，session 失效后 token 自动作废，返回 404。",
+          confidence: "high",
+          how_xhs_decides:
+            "服务端用 web_session 解密 xsec_token 中的加密字段，" +
+            "session 失效则解密失败 → 404。",
+        };
+      } else if (blockType === "content_removed") {
+        diagnosis = {
+          root_cause: "内容已被删除 / 下架（note.status 异常）",
+          cause_category: "content_unavailable",
+          detail:
+            "HTTP 200 正常返回，但 __INITIAL_STATE__ 中的 note.status 为 banned / deleted / invisible，" +
+            "前端据此渲染 404 组件。与 URL 或 session 无关，是内容本身的状态问题。",
+          confidence: "high",
+          how_xhs_decides:
+            "服务端在 note 数据中携带 status 字段，前端 Vue 组件检查此字段，" +
+            "非 normal 状态则渲染 notFound 页面，HTTP 状态码仍是 200。",
+        };
+      } else if (xsecToken && cookies.has_web_session) {
+        diagnosis = {
+          root_cause: `xsec_token 与当前 session / IP 绑定验证失败（来源: ${xsecSource || "未知"}）`,
+          cause_category: "token",
+          detail:
+            "token 和 session 均存在，但服务端验证绑定关系失败。\n" +
+            "可能原因：\n" +
+            "  1. token 超过有效期（通常数小时）\n" +
+            "  2. IP 变化导致 token 中的 ipHash 不匹配\n" +
+            `  3. xsec_source="${xsecSource}" 与实际访问场景不符`,
+          confidence: "medium",
+          how_xhs_decides:
+            "服务端解密 xsec_token 后逐字段校验：noteId、userId、ipHash、ts、source，任一不符 → 404。",
+        };
+      } else {
+        diagnosis = {
+          root_cause: "IP / 账号级风控封禁（凭证齐全但仍被拦截）",
+          cause_category: "risk_control",
+          detail:
+            "所有凭证均存在，但页面仍渲染 404。" +
+            "这是 XHS 对高风险 IP / 账号的内容屏蔽策略：" +
+            "不直接封号，而是让特定内容【消失】，降低用户对封禁的察觉。",
+          confidence: "medium",
+          how_xhs_decides:
+            "服务端对 {IP, userId, deviceId} 三元组计算行为评分，" +
+            "低于阈值时对内容请求返回 404，登录态保持正常。",
+        };
+      }
+
+      return {
+        id:             `${Date.now()}_nav`,
+        timestamp:      new Date().toISOString(),
+        url:            targetUrl,
+        final_url:      landedUrl || window.location.href,
+        redirect_source: redirectSource,
+        method:         "GET",
+        status:         httpLike404 ? 404 : "200→404",
+        pageUrl:        window.location.href,
+        intercept_type: "navigation",
+        block_type:     blockType,
+        request: {
+          xsec_token:    xsecToken,
+          xsec_source:   xsecSource,
+          has_xs:        false,   // 导航请求不含 xs header
+          has_xt:        false,
+          has_referer:   !!document.referrer,
+          sec_fetch_site: null,
+          content_type:   null,
+        },
+        cookies,
+        diagnosis,
+      };
+    },
+    args: [navigatedUrl, finalUrl || ""],
+  });
+
+  const event = results?.[0]?.result;
+  if (event) {
+    await storeBlockEvent(event);
+    chrome.runtime.sendMessage({ type: "BLOCK_EVENT_ADDED", event }).catch(() => {});
+    console.log(`[XHS Bridge] 导航 404 已捕获: ${event.diagnosis.root_cause}`);
+  }
+  return event || null;
+}
+
+// ── 从 URL 中提取笔记 ID ────────────────────────────────────
+function extractNoteId(url) {
+  const m = url.match(/\/explore\/([a-f0-9]{20,})/);
+  return m ? m[1] : null;
+}
+
+// ── 通过搜索页获取笔记的最新 xsec_token ─────────────────────
+async function getFreshXsecToken(tabId, noteId) {
+  const searchUrl =
+    "https://www.xiaohongshu.com/search_result?" +
+    `keyword=${encodeURIComponent(noteId)}&type=51&source=web_search_note`;
+
+  try {
+    await chrome.tabs.update(tabId, { url: searchUrl });
+    await waitForTabComplete(tabId, null, 20000);
+    await sleep(1800);  // 等待 Vue 渲染完成
+
+    const results = await chrome.scripting.executeScript({
+      target: { tabId },
+      world: "MAIN",
+      func: (nid) => {
+        // 方法 1：__INITIAL_STATE__ 搜索结果
+        try {
+          const s = window.__INITIAL_STATE__;
+          const pool = [
+            ...(s?.search?.noteResults  || []),
+            ...(s?.search?.items        || []),
+            ...(s?.searchResult?.items  || []),
+          ];
+          for (const item of pool) {
+            const id    = item.id || item.noteId || item.note?.noteId;
+            const token = item.xsecToken || item.note?.xsecToken;
+            if (id === nid && token) return token;
+          }
+        } catch (_) {}
+
+        // 方法 2：DOM 链接
+        const links = document.querySelectorAll(`a[href*="${nid}"]`);
+        for (const link of links) {
+          const href = link.href || link.getAttribute("href") || "";
+          const m = href.match(/xsec_token=([^&]+)/);
+          if (m) return decodeURIComponent(m[1]);
+        }
+        return null;
+      },
+      args: [noteId],
+    });
+
+    return results?.[0]?.result || null;
+  } catch (_) {
+    return null;
+  }
+}
+
+async function cmdNavigate({ url, _retried = false }) {
   const tab = await getOrOpenXhsTab();
-  await chrome.tabs.update(tab.id, { url });
+
+  // 若当前已在 xiaohongshu.com，用页面内 window.location.href 发起导航。
+  // 这样浏览器将导航标记为 same-origin（Sec-Fetch-Site: same-origin），
+  // 与真实用户点击链接行为一致，避免 chrome.tabs.update 产生的
+  // Sec-Fetch-Site: none/cross-site 被 XHS 服务端识别为自动化访问。
+  const isOnXhs = tab.url && tab.url.includes("xiaohongshu.com");
+  if (isOnXhs) {
+    await chrome.scripting.executeScript({
+      target: { tabId: tab.id },
+      world: "MAIN",
+      func: (targetUrl) => { window.location.href = targetUrl; },
+      args: [url],
+    });
+  } else {
+    await chrome.tabs.update(tab.id, { url });
+  }
+
   await waitForTabComplete(tab.id, url, 60000);
+
+  // ── 最终落地 URL 检测：XHS 风控 302 重定向到 /404?source=原路径 ──
+  const finalTab = await chrome.tabs.get(tab.id).catch(() => null);
+  const finalUrl = finalTab?.url || "";
+  if (/xiaohongshu\.com\/404(\?|$)/.test(finalUrl)) {
+    // 优先使用 webRequest 观测器已存储的诊断（捕获的是第一跳 302，最准确）
+    // webRequest 事件写入是异步的，稍等一下确保已落盘
+    await sleep(400);
+    let event = null;
+    const stored = await chrome.storage.session.get("blockEvents").catch(() => ({}));
+    // 用时间窗口（60s）+ URL 包含关系匹配，避免 query 参数顺序差异导致精确匹配失败
+    const nowMs = Date.now();
+    const recent = (stored.blockEvents || []).find(
+      e => e.intercept_type === "webRequest_302" &&
+           e.url && url.includes(e.url.split("?")[0].split("/").pop()) &&
+           (nowMs - new Date(e.timestamp).getTime()) < 60000,
+    );
+    if (recent) {
+      event = recent;
+    } else {
+      // fallback：DOM 分析（落地在 /404 页面，准确度较低）
+      event = await detectNavigationBlock(tab.id, url, finalUrl).catch(() => null);
+    }
+
+    const cause = event?.diagnosis?.cause_category;
+    const errorCode = event?.trigger?.primary?.match(/error_code=(\d+)/)?.[1] || null;
+
+    // ── Auto-fix：token 过期/缺失时，从搜索页取新 token 重试 ──
+    //
+    // 只在以下情况尝试：
+    //   1. 没有重试过（_retried=false）
+    //   2. 原因是 token 类问题
+    //   3. error_code 是 300032（过期）或没有 error_code（参数缺失）
+    //      300031 = token 签名错误（可能是内容下架伪装），重试无意义
+    //      300033 = IP 绑定不匹配，换 token 有意义
+    const tokenExpiredOrMissing = !errorCode || errorCode === "300032" || errorCode === "300033";
+    if (!_retried && cause === "token" && tokenExpiredOrMissing) {
+      const noteId = extractNoteId(url);
+      if (noteId) {
+        console.log(`[XHS Bridge] token 过期/缺失（error_code=${errorCode || "无"}），搜索页取新 token（noteId=${noteId}）...`);
+        const freshToken = await getFreshXsecToken(tab.id, noteId).catch(() => null);
+        if (freshToken) {
+          const u = new URL(url);
+          u.searchParams.set("xsec_token", freshToken);
+          u.searchParams.set("xsec_source", "pc_search");
+          const fixedUrl = u.toString();
+          console.log(`[XHS Bridge] 获取新 token 成功，重新导航: ${fixedUrl}`);
+          return cmdNavigate({ url: fixedUrl, _retried: true });
+        }
+        console.log("[XHS Bridge] 未能从搜索页获取新 token，内容可能已被删除");
+      }
+    }
+    // 300031 且已有有效 token = 内容本身不可访问（删除/下架/区域限制）
+    if (errorCode === "300031" && event?.url_params?.xsec_token) {
+      const rootCause2 = event.diagnosis.root_cause;
+      throw new Error(`笔记内容不可访问（已删除/下架/区域限制），服务端以 token 错误掩盖真实原因：${rootCause2}`);
+    }
+
+    const rootCause = event?.diagnosis?.root_cause || "未知原因";
+    throw new Error(`笔记被风控拦截（${rootCause}），重定向至: ${finalUrl}`);
+  }
+
+  // ── 页面渲染级 404 检测（HTTP 200 但 SPA 渲染出错误页）──
+  await detectNavigationBlock(tab.id, url, finalUrl).catch(() => {});
+
+  // 注入 visibilityState 伪装：XHS 监听页面可见性，后台标签页会暂停 Vue 渲染。
+  // 覆盖后页面始终认为自己在前台，允许在后台标签页正常提取数据。
+  await chrome.scripting.executeScript({
+    target: { tabId: tab.id },
+    world: "MAIN",
+    func: () => {
+      try {
+        Object.defineProperty(document, "visibilityState", {
+          get: () => "visible",
+          configurable: true,
+        });
+        Object.defineProperty(document, "hidden", {
+          get: () => false,
+          configurable: true,
+        });
+        document.dispatchEvent(new Event("visibilitychange"));
+      } catch (_) {}
+    },
+  }).catch(() => {});
+
   return null;
 }
 
@@ -219,7 +700,15 @@ function mainWorldExecutor(method, params) {
 
     case "get_element_text": {
       const el = document.querySelector(params.selector);
-      return el ? el.textContent : null;
+      return el ? el.textContent.trim() : null;
+    }
+
+    case "get_elements_info": {
+      return Array.from(document.querySelectorAll(params.selector)).map(el => {
+        const info = { text: el.textContent.trim() };
+        if (params.attrs) for (const a of params.attrs) info[a] = el.getAttribute(a);
+        return info;
+      });
     }
 
     case "get_element_attribute": {
@@ -261,9 +750,207 @@ function mainWorldExecutor(method, params) {
       ).catch(() => { throw new Error(`等待元素超时: ${params.selector}`); });
     }
 
+    case "get_iframe_text": {
+      return new Promise(resolve => {
+        const iframe = document.querySelector(params.iframe_selector);
+        if (!iframe) { resolve(null); return; }
+        function tryRead() {
+          try {
+            const doc = iframe.contentDocument || iframe.contentWindow?.document;
+            if (!doc || doc.readyState !== "complete") return false;
+            const spans = doc.querySelectorAll(params.text_selector || ".textLayer span");
+            if (spans.length === 0) return false;
+            return Array.from(spans).map(s => s.textContent).join(" ");
+          } catch (e) {
+            return { __xhs_error: `iframe 访问失败: ${e.message}` };
+          }
+        }
+        const timeout = params.timeout || 15000;
+        const start = Date.now();
+        (function tick() {
+          const result = tryRead();
+          if (result && result !== false) { resolve(result); return; }
+          if (result?.__xhs_error) { resolve(result); return; }
+          if (Date.now() - start >= timeout) { resolve(null); return; }
+          setTimeout(tick, 300);
+        })();
+      });
+    }
+
     default:
       return { __xhs_error: `未知 MAIN world 方法: ${method}` };
   }
+}
+
+// ───────────────────────── 工具函数 ──────────────────────────────────
+
+function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
+
+// ───────────────────────── 真实鼠标点击（chrome.debugger + CDP） ──────
+
+async function cmdClickViaDebugger(method, { selector, index, text }) {
+  const tab = await getOrOpenXhsTab();
+  const target = { tabId: tab.id };
+
+  // 按调用方式构造元素查找表达式
+  let findExpr;
+  if (method === "click_nth_element") {
+    findExpr = `document.querySelectorAll(${JSON.stringify(selector)})[${index}] || null`;
+  } else if (method === "click_element_by_text") {
+    findExpr = `Array.from(document.querySelectorAll(${JSON.stringify(selector)})).find(e => e.textContent.includes(${JSON.stringify(text)})) || null`;
+  } else {
+    findExpr = `document.querySelector(${JSON.stringify(selector)})`;
+  }
+
+  await chrome.debugger.attach(target, "1.3");
+  try {
+    // 先滚动元素到视口中心，再取坐标
+    const evalResult = await chrome.debugger.sendCommand(target, "Runtime.evaluate", {
+      expression: `(() => {
+        const el = ${findExpr};
+        if (!el) return null;
+        el.scrollIntoView({ block: "center", behavior: "instant" });
+        const r = el.getBoundingClientRect();
+        return { x: r.left + r.width / 2, y: r.top + r.height / 2 };
+      })()`,
+      returnByValue: true,
+    });
+
+    const pos = evalResult?.result?.value;
+    if (!pos) throw new Error(`元素不存在: ${JSON.stringify({ selector, index, text })}`);
+
+    // 鼠标轨迹：从上方偏移处移动到目标点（5 步）
+    const startX = pos.x - 20;
+    const startY = pos.y - 45;
+    const steps = 5;
+    for (let i = 1; i <= steps; i++) {
+      const t = i / steps;
+      await chrome.debugger.sendCommand(target, "Input.dispatchMouseEvent", {
+        type: "mouseMoved",
+        x: Math.round(startX + (pos.x - startX) * t),
+        y: Math.round(startY + (pos.y - startY) * t),
+        button: "none", buttons: 0, modifiers: 0,
+      });
+      await sleep(8);
+    }
+
+    const base = { x: pos.x, y: pos.y, button: "left", buttons: 1, clickCount: 1, modifiers: 0 };
+    await chrome.debugger.sendCommand(target, "Input.dispatchMouseEvent", { ...base, type: "mousePressed" });
+    await sleep(30);
+    await chrome.debugger.sendCommand(target, "Input.dispatchMouseEvent", { ...base, type: "mouseReleased", buttons: 0 });
+  } finally {
+    await chrome.debugger.detach(target).catch(() => {});
+  }
+  return null;
+}
+
+// ─────── 真实键盘（chrome.debugger + CDP Input.dispatchKeyEvent） ──────
+
+async function cmdPressKeyViaDebugger({ key }) {
+  const tab = await getOrOpenXhsTab();
+
+  // 检查当前焦点是否在 contenteditable
+  const ceResult = await chrome.scripting.executeScript({
+    target: { tabId: tab.id },
+    world: "MAIN",
+    func: () => document.activeElement?.isContentEditable ?? false,
+  });
+  const inCE = ceResult?.[0]?.result;
+
+  if (inCE) {
+    // contenteditable: execCommand 产生 isTrusted input 事件
+    await chrome.scripting.executeScript({
+      target: { tabId: tab.id },
+      world: "MAIN",
+      func: (k) => {
+        if (k === "Enter") {
+          document.execCommand("insertParagraph", false, null);
+        } else if (k === "ArrowDown") {
+          const active = document.activeElement;
+          const sel = window.getSelection();
+          if (sel && active.childNodes.length) {
+            sel.selectAllChildren(active);
+            sel.collapseToEnd();
+          }
+        } else if (k === "Backspace") {
+          document.execCommand("delete", false, null);
+        }
+      },
+      args: [key],
+    });
+    return null;
+  }
+
+  // 非 contenteditable: debugger Input.dispatchKeyEvent（isTrusted: true）
+  const KEY_MAP = {
+    Enter:      { key: "Enter",      code: "Enter",      windowsVirtualKeyCode: 13 },
+    Tab:        { key: "Tab",        code: "Tab",        windowsVirtualKeyCode: 9  },
+    Backspace:  { key: "Backspace",  code: "Backspace",  windowsVirtualKeyCode: 8  },
+    Delete:     { key: "Delete",     code: "Delete",     windowsVirtualKeyCode: 46 },
+    Escape:     { key: "Escape",     code: "Escape",     windowsVirtualKeyCode: 27 },
+    ArrowDown:  { key: "ArrowDown",  code: "ArrowDown",  windowsVirtualKeyCode: 40 },
+    ArrowUp:    { key: "ArrowUp",    code: "ArrowUp",    windowsVirtualKeyCode: 38 },
+    ArrowLeft:  { key: "ArrowLeft",  code: "ArrowLeft",  windowsVirtualKeyCode: 37 },
+    ArrowRight: { key: "ArrowRight", code: "ArrowRight", windowsVirtualKeyCode: 39 },
+    Space:      { key: " ",          code: "Space",      windowsVirtualKeyCode: 32 },
+  };
+  const info = KEY_MAP[key] || { key, code: `Key${key.toUpperCase()}`, windowsVirtualKeyCode: key.charCodeAt(0) };
+
+  const target = { tabId: tab.id };
+  await chrome.debugger.attach(target, "1.3");
+  try {
+    const base = { modifiers: 0, ...info };
+    await chrome.debugger.sendCommand(target, "Input.dispatchKeyEvent", { ...base, type: "keyDown" });
+    await sleep(30);
+    await chrome.debugger.sendCommand(target, "Input.dispatchKeyEvent", { ...base, type: "keyUp" });
+  } finally {
+    await chrome.debugger.detach(target).catch(() => {});
+  }
+  return null;
+}
+
+// ─────── 真实文字输入（chrome.debugger + CDP Input.insertText） ──────
+
+async function cmdTypeTextViaDebugger({ text, delayMs = 50 }) {
+  const tab = await getOrOpenXhsTab();
+
+  // 检查当前焦点是否在 contenteditable
+  const ceResult = await chrome.scripting.executeScript({
+    target: { tabId: tab.id },
+    world: "MAIN",
+    func: () => document.activeElement?.isContentEditable ?? false,
+  });
+  const inCE = ceResult?.[0]?.result;
+
+  if (inCE) {
+    // contenteditable: 逐字 execCommand("insertText")，单次 executeScript 避免 IPC 开销
+    await chrome.scripting.executeScript({
+      target: { tabId: tab.id },
+      world: "MAIN",
+      func: async (chars, delay) => {
+        function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
+        for (const char of chars) {
+          document.execCommand("insertText", false, char);
+          await sleep(delay);
+        }
+      },
+      args: [[...text], delayMs],
+    });
+    return null;
+  }
+
+  // 非 contenteditable: 逐字 Input.insertText（isTrusted: true）
+  const target = { tabId: tab.id };
+  await chrome.debugger.attach(target, "1.3");
+  try {
+    for (const char of text) {
+      await chrome.debugger.sendCommand(target, "Input.insertText", { text: char });
+      await sleep(delayMs);
+    }
+  } finally {
+    await chrome.debugger.detach(target).catch(() => {});
+  }
+  return null;
 }
 
 // ───────────────────────── 文件上传（chrome.debugger + CDP） ─────────
@@ -321,15 +1008,6 @@ function domExecutor(method, params) {
   }
 
   switch (method) {
-    case "click_element": {
-      const el = requireEl(params.selector);
-      if (el.__xhs_error) return el;
-      el.scrollIntoView({ block: "center" });
-      el.focus();
-      el.click();
-      return null;
-    }
-
     case "input_text": {
       const el = requireEl(params.selector);
       if (el.__xhs_error) return el;
@@ -440,52 +1118,6 @@ function domExecutor(method, params) {
       return null;
     }
 
-    case "press_key": {
-      const active = document.activeElement || document.body;
-      const inCE = active.isContentEditable;
-      if (inCE && params.key === "Enter") {
-        document.execCommand("insertParagraph", false, null);
-        return null;
-      }
-      if (inCE && params.key === "ArrowDown") {
-        // 将光标移到内容末尾（等价于多次下移到底）
-        const sel = window.getSelection();
-        if (sel && active.childNodes.length) {
-          sel.selectAllChildren(active);
-          sel.collapseToEnd();
-        }
-        return null;
-      }
-      const keyMap = {
-        Enter: { key: "Enter", code: "Enter", keyCode: 13 },
-        ArrowDown: { key: "ArrowDown", code: "ArrowDown", keyCode: 40 },
-        Tab: { key: "Tab", code: "Tab", keyCode: 9 },
-        Backspace: { key: "Backspace", code: "Backspace", keyCode: 8 },
-      };
-      const info = keyMap[params.key] || { key: params.key, code: params.key, keyCode: 0 };
-      active.dispatchEvent(new KeyboardEvent("keydown", { ...info, bubbles: true }));
-      active.dispatchEvent(new KeyboardEvent("keyup", { ...info, bubbles: true }));
-      return null;
-    }
-
-    case "type_text": {
-      return new Promise(async (resolve) => {
-        const active = document.activeElement || document.body;
-        const inCE = active.isContentEditable;
-        for (const char of params.text) {
-          if (inCE) {
-            document.execCommand("insertText", false, char);
-          } else {
-            active.dispatchEvent(new KeyboardEvent("keydown", { key: char, bubbles: true }));
-            active.dispatchEvent(new KeyboardEvent("keypress", { key: char, bubbles: true }));
-            active.dispatchEvent(new KeyboardEvent("keyup", { key: char, bubbles: true }));
-          }
-          await sleep(params.delayMs || 50);
-        }
-        resolve(null);
-      });
-    }
-
     case "remove_element": {
       const el = document.querySelector(params.selector);
       if (el) el.remove();
@@ -512,6 +1144,461 @@ function domExecutor(method, params) {
     default:
       return { __xhs_error: `未知 DOM 命令: ${method}` };
   }
+}
+
+// ─── 302→/404 真实触发机制观测器 ─────────────────────────────────────────────
+//
+// 使用 webRequest API，在浏览器跟随 302 之前捕获原始 HTTP 上下文。
+// 这是唯一能看到服务端判断依据的方法：
+//   Phase 1  onBeforeSendHeaders — 记录发出去的请求头（含 Cookie、Sec-Fetch-* 等）
+//   Phase 2  onHeadersReceived   — 检测 302 响应，Location → /404 时触发分析
+//
+// 两阶段用 requestId 关联，因此能完整重建"XHS 收到什么请求 → 决定 302"的因果链。
+
+const _reqCache = new Map();  // requestId → 请求上下文（Phase 1 填充）
+
+chrome.webRequest.onBeforeSendHeaders.addListener(
+  (details) => {
+    // 只缓存页面级导航（main_frame）和 XHR/fetch，跳过图片/字体等资源
+    if (!["main_frame", "sub_frame", "xmlhttprequest", "fetch"].includes(details.type)) return;
+
+    const reqHeaders = {};
+    for (const h of details.requestHeaders || []) {
+      reqHeaders[h.name.toLowerCase()] = h.value;
+    }
+
+    // 限制 Map 大小，防止 service worker 内存泄漏
+    if (_reqCache.size > 200) {
+      const firstKey = _reqCache.keys().next().value;
+      _reqCache.delete(firstKey);
+    }
+
+    _reqCache.set(details.requestId, {
+      url:            details.url,
+      method:         details.method,
+      type:           details.type,
+      tabId:          details.tabId,
+      ts:             Date.now(),
+      requestHeaders: reqHeaders,
+    });
+  },
+  {
+    urls: ["https://www.xiaohongshu.com/*", "https://xiaohongshu.com/*"],
+  },
+  ["requestHeaders", "extraHeaders"],
+);
+
+chrome.webRequest.onHeadersReceived.addListener(
+  (details) => {
+    const reqCtx = _reqCache.get(details.requestId);
+    // Phase 2 完成后清理缓存（无论是否 302）
+    _reqCache.delete(details.requestId);
+
+    if (details.statusCode !== 301 && details.statusCode !== 302) return;
+
+    // 跳过 /404 路径本身的二次跳转（只捕获第一跳：内容 URL → /404）
+    // XHS 的重定向链：/explore/{id} → /404/sec_xxx → /404?source=...
+    // 我们只要第一跳，它包含真实的 error_code 和 token 状态
+    if (/\/404(\/|$|\?)/.test(details.url)) return;
+
+    // 找 Location 响应头
+    const locationHeader = (details.responseHeaders || [])
+      .find(h => h.name.toLowerCase() === "location");
+    const location = locationHeader?.value || "";
+
+    // 只关心重定向到 /404 的（XHS 风控标志）
+    if (!/\/404(\/|$|\?)/.test(location)) return;
+
+    // ── 解析请求 URL 关键参数 ──────────────────────────────────
+    let urlParams = { path: "", xsec_token: null, xsec_source: null };
+    try {
+      const u = new URL(details.url);
+      urlParams.path         = u.pathname;
+      urlParams.xsec_token   = u.searchParams.get("xsec_token");
+      urlParams.xsec_source  = u.searchParams.get("xsec_source");
+    } catch (_) {}
+
+    // ── 解析请求 Cookie（从请求头中提取） ─────────────────────
+    const cookieStr = reqCtx?.requestHeaders?.["cookie"] || "";
+    const cookieMap = {};
+    for (const p of cookieStr.split(";")) {
+      const i = p.indexOf("=");
+      if (i < 0) continue;
+      cookieMap[p.slice(0, i).trim()] = p.slice(i + 1).trim();
+    }
+    const cookieAnalysis = {
+      has_a1:              "a1" in cookieMap,
+      has_web_session:     "web_session" in cookieMap,
+      has_webId:           "webId" in cookieMap,
+      a1_preview:          cookieMap["a1"]          ? cookieMap["a1"].slice(0, 12)          + "…" : null,
+      web_session_preview: cookieMap["web_session"] ? cookieMap["web_session"].slice(0, 10) + "…" : null,
+    };
+
+    // ── 收集 302 响应头 ────────────────────────────────────────
+    const respHeaders = {};
+    for (const h of details.responseHeaders || []) {
+      respHeaders[h.name.toLowerCase()] = h.value;
+    }
+
+    // ── 触发机制判断（基于实测 HTTP 数据） ─────────────────────
+    //
+    // 观测到 302 时，通过请求头和 URL 参数推断 XHS 服务端做了什么判断：
+    //
+    //  A. Cookie 无 web_session   → 服务端无法解密 token，路由层立即 302
+    //  B. URL 无 xsec_token       → 路由层参数校验失败，立即 302（早于业务逻辑）
+    //  C. 两者都有但仍 302         → token 解密成功但内容验证失败
+    //                               （ipHash / ts / source / userId 不匹配）
+    //
+    // Sec-Fetch-Site 是额外的观测维度：
+    //  "none"       = 直接导航（地址栏/bookmark），是自动化的强信号
+    //  "same-origin" = 从 XHS 页面内部点击/跳转，最安全
+    //  "cross-site"  = 从外部页面跳来（不可信）
+
+    let triggerPrimary, triggerEvidence, causeCategory;
+    const secFetchSite = reqCtx?.requestHeaders?.["sec-fetch-site"];
+
+    // 从 302 Location 里解析 XHS 服务端给出的 error_code
+    // 格式：/404/sec_xxx?redirectPath=...&error_code=300031&error_msg=...
+    let errorCode = null, errorMsg = null;
+    try {
+      const locUrl = new URL(location, "https://www.xiaohongshu.com");
+      errorCode = locUrl.searchParams.get("error_code");
+      errorMsg  = decodeURIComponent(locUrl.searchParams.get("error_msg") || "");
+    } catch (_) {}
+
+    // error_code 语义（实测）：
+    //   300031 = token 签名验证失败（格式错误 / 签名不匹配）
+    //   300032 = token 过期（ts 字段超有效期）
+    //   300033 = token 与 session/IP 绑定不匹配
+    //   无 error_code = 路由层参数缺失（最外层，token 不存在）
+    const ERROR_CODE_MEANING = {
+      "300031": "token 签名验证失败（格式/签名错误）",
+      "300032": "token 已过期",
+      "300033": "token 与当前 session / IP 绑定不匹配",
+    };
+
+    if (!cookieAnalysis.has_web_session) {
+      triggerPrimary  = "web_session 不存在 → 服务端无法鉴权，302";
+      triggerEvidence = "Cookie 头中无 web_session 字段，token 解密密钥缺失";
+      causeCategory   = "session";
+    } else if (!urlParams.xsec_token) {
+      triggerPrimary  = "URL 缺少 xsec_token 参数 → 路由层参数校验失败，302";
+      triggerEvidence = `路径 ${urlParams.path} 无 xsec_token 查询参数`;
+      causeCategory   = "token";
+    } else if (errorCode) {
+      const meaning   = ERROR_CODE_MEANING[errorCode] || `未知错误码 ${errorCode}`;
+      triggerPrimary  = `xsec_token 验证失败（error_code=${errorCode}）→ ${meaning}`;
+      triggerEvidence =
+        `token 前缀=${urlParams.xsec_token.slice(0, 20)}… source=${urlParams.xsec_source || "无"}` +
+        `，error_msg="${errorMsg}"，Sec-Fetch-Site=${secFetchSite || "无"}`;
+      causeCategory   = "token";
+    } else {
+      triggerPrimary  = "xsec_token 内容验证失败 → 服务端解密后字段不匹配，302";
+      triggerEvidence =
+        `token 前缀=${urlParams.xsec_token.slice(0, 20)}… source=${urlParams.xsec_source || "无"}` +
+        `，Sec-Fetch-Site=${secFetchSite || "无"}`;
+      causeCategory   = "token";
+    }
+
+    const event = {
+      id:             `${Date.now()}_302webreq`,
+      timestamp:      new Date().toISOString(),
+      intercept_type: "webRequest_302",          // 区分于 fetch/XHR 拦截
+
+      // ── 请求上下文（Phase 1 采集）──
+      url:            details.url,
+      method:         details.method,
+      resource_type:  reqCtx?.type || details.type,
+      redirect_to:    location,
+
+      url_params: urlParams,
+
+      // 自动化指纹相关请求头（XHS 服务端可以看到这些）
+      request_fingerprint: {
+        "sec-fetch-site":   secFetchSite,
+        "sec-fetch-mode":   reqCtx?.requestHeaders?.["sec-fetch-mode"],
+        "sec-fetch-dest":   reqCtx?.requestHeaders?.["sec-fetch-dest"],
+        "referer":          reqCtx?.requestHeaders?.["referer"],
+        "origin":           reqCtx?.requestHeaders?.["origin"],
+        "user-agent":       reqCtx?.requestHeaders?.["user-agent"]?.slice(0, 100),
+      },
+
+      cookies: cookieAnalysis,
+
+      // ── 302 响应头（Phase 2 采集）—— 服务端返回的原始信号 ──
+      response_302_headers: {
+        location:           respHeaders["location"],
+        "cache-control":    respHeaders["cache-control"],
+        "x-request-id":     respHeaders["x-request-id"],
+        "set-cookie":       respHeaders["set-cookie"],
+        server:             respHeaders["server"],
+      },
+
+      // ── 触发机制分析 ──
+      trigger: {
+        primary:            triggerPrimary,
+        evidence:           triggerEvidence,
+        sec_fetch_site:     secFetchSite,
+        is_direct_nav:      secFetchSite === "none",  // 地址栏/自动化直接导航的特征
+      },
+
+      // 兼容现有诊断格式
+      diagnosis: {
+        root_cause:      triggerPrimary,
+        cause_category:  causeCategory,
+        detail:          triggerEvidence,
+        how_xhs_decides:
+          "webRequest 层实测捕获。" +
+          "XHS 在 CDN/路由层校验 xsec_token 参数存在性（最外层）；" +
+          "通过后进入签名层用 web_session 解密 token 内容；" +
+          "最后核对 {noteId, userId, ipHash, ts, source} 各字段。",
+      },
+    };
+
+    storeBlockEvent(event).catch(() => {});
+    chrome.runtime.sendMessage({ type: "BLOCK_EVENT_ADDED", event }).catch(() => {});
+    console.log(
+      `[XHS 302观测] ${triggerPrimary}\n` +
+      `  URL: ${details.url.slice(0, 100)}\n` +
+      `  Sec-Fetch-Site: ${secFetchSite || "无"} | xsec_token: ${urlParams.xsec_token ? "有" : "无"}`,
+    );
+  },
+  {
+    urls: ["https://www.xiaohongshu.com/*", "https://xiaohongshu.com/*"],
+  },
+  ["responseHeaders", "extraHeaders"],
+);
+
+// 非 302 请求完成时清理缓存
+chrome.webRequest.onCompleted.addListener(
+  (d) => _reqCache.delete(d.requestId),
+  { urls: ["https://www.xiaohongshu.com/*", "https://xiaohongshu.com/*"] },
+);
+chrome.webRequest.onErrorOccurred.addListener(
+  (d) => _reqCache.delete(d.requestId),
+  { urls: ["https://www.xiaohongshu.com/*", "https://xiaohongshu.com/*"] },
+);
+
+// ───────────────────────── 404 诊断事件存储 ──────────────────
+
+const MAX_BLOCK_EVENTS = 50;
+
+async function storeBlockEvent(event) {
+  const data = await chrome.storage.session.get("blockEvents");
+  const events = data.blockEvents || [];
+  events.unshift(event);                        // 最新的在前
+  if (events.length > MAX_BLOCK_EVENTS) events.length = MAX_BLOCK_EVENTS;
+  await chrome.storage.session.set({ blockEvents: events });
+}
+
+// ───────────────────────── 风控分析 ─────────────────────────
+
+async function cmdAnalyzeRiskControl({ probeUrls = [] } = {}) {
+  const tab = await getOrOpenXhsTab();
+  const results = await chrome.scripting.executeScript({
+    target: { tabId: tab.id },
+    world: "MAIN",
+    func: riskControlAnalyzer,
+    args: [probeUrls],
+  });
+  return results?.[0]?.result ?? null;
+}
+
+/**
+ * 在页面 MAIN world 执行风控分析。
+ * 必须完全自包含，不可引用任何外部变量。
+ */
+async function riskControlAnalyzer(extraProbeUrls) {
+  const report = {
+    timestamp: new Date().toISOString(),
+    fingerprints: {},
+    page_state: {},
+    api_probes: {},
+    risk_level: "safe",
+    issues: [],
+  };
+
+  // ── 1. 自动化指纹检测 ─────────────────────────────────────────
+  const fp = report.fingerprints;
+
+  fp.webdriver = navigator.webdriver;
+  fp.plugins_count = navigator.plugins.length;
+  fp.languages = Array.from(navigator.languages || []);
+  fp.user_agent = navigator.userAgent;
+  fp.is_headless_ua = /HeadlessChrome|Electron\/|PhantomJS/.test(navigator.userAgent);
+  fp.outer_width = window.outerWidth;
+  fp.outer_height = window.outerHeight;
+  fp.screen_width = screen.width;
+  fp.screen_height = screen.height;
+  fp.color_depth = screen.colorDepth;
+  fp.device_memory = navigator.deviceMemory;
+  fp.hardware_concurrency = navigator.hardwareConcurrency;
+  fp.platform = navigator.platform;
+  fp.chrome_exists = typeof window.chrome !== "undefined";
+  fp.chrome_runtime = !!(window.chrome && window.chrome.runtime);
+  fp.visibility_state = document.visibilityState;
+  fp.document_hidden = document.hidden;
+
+  // 权限探测（无头浏览器 notifications 默认 denied）
+  try {
+    const perm = await navigator.permissions.query({ name: "notifications" });
+    fp.notifications_permission = perm.state;
+  } catch (_) {
+    fp.notifications_permission = "error";
+  }
+
+  // WebGL 软件渲染检测（SwiftShader = 无头特征）
+  try {
+    const canvas = document.createElement("canvas");
+    const gl = canvas.getContext("webgl") || canvas.getContext("experimental-webgl");
+    if (gl) {
+      const dbg = gl.getExtension("WEBGL_debug_renderer_info");
+      if (dbg) {
+        fp.webgl_vendor   = gl.getParameter(dbg.UNMASKED_VENDOR_WEBGL);
+        fp.webgl_renderer = gl.getParameter(dbg.UNMASKED_RENDERER_WEBGL);
+        fp.webgl_is_swiftshader = /SwiftShader|llvmpipe|softpipe/i.test(fp.webgl_renderer || "");
+      }
+    }
+  } catch (_) {}
+
+  // ── 2. 页面状态 / XHS 专项检测 ───────────────────────────────
+  const ps = report.page_state;
+
+  ps.current_url = window.location.href;
+  ps.page_title  = document.title;
+
+  try {
+    const state = window.__INITIAL_STATE__;
+    if (state) {
+      ps.has_initial_state = true;
+      ps.user_logged_in    = !!(state?.user?.userInfo?.userId || state?.login?.userInfo?.userId);
+      const riskKeys = ["riskControl", "blockReason", "needVerification", "forbidden"];
+      ps.state_risk_keys   = riskKeys.filter(k => k in state);
+    } else {
+      ps.has_initial_state = false;
+    }
+  } catch (_) {
+    ps.has_initial_state = false;
+  }
+
+  ps.has_captcha_modal  = !!(
+    document.querySelector('[class*="captcha"]') ||
+    document.querySelector('[class*="verify-modal"]') ||
+    document.querySelector("#captcha-container")
+  );
+  ps.page_is_404        = document.title.includes("404") ||
+    !!(document.querySelector('[class*="not-found"]') || document.querySelector('[class*="error-page"]'));
+  ps.page_has_risk_block = !!(
+    document.querySelector('[class*="risk-block"]') ||
+    document.querySelector('[class*="forbidden-page"]')
+  );
+
+  // 扫描当前页面已有的 API 请求失败记录（Chrome 109+ 支持 responseStatus）
+  const resFailed = [];
+  for (const r of performance.getEntriesByType("resource")) {
+    if (r.name.includes("xiaohongshu.com") && r.name.includes("/api/")) {
+      const s = r.responseStatus;
+      if (s && (s === 404 || s === 461 || s === 403 || s === 999)) {
+        resFailed.push({ url: r.name, status: s });
+      }
+    }
+  }
+  ps.api_failures_on_page = resFailed;
+
+  // ── 3. 实时 API 探测 ─────────────────────────────────────────
+  const defaultProbes = [
+    {
+      key: "/api/sns/web/v1/search/complete",
+      url: "https://www.xiaohongshu.com/api/sns/web/v1/search/complete?keyword=test",
+      method: "GET",
+    },
+    {
+      key: "/api/sns/web/v1/homefeed",
+      url: "https://www.xiaohongshu.com/api/sns/web/v1/homefeed",
+      method: "POST",
+      body: JSON.stringify({ cursor_score: "", num: 1, refresh_type: 1, note_index: 1 }),
+    },
+    {
+      key: "/api/sns/web/v2/user/me",
+      url: "https://www.xiaohongshu.com/api/sns/web/v2/user/me",
+      method: "GET",
+    },
+  ];
+
+  const probes = [
+    ...defaultProbes,
+    ...extraProbeUrls.map(u => ({ key: u, url: u, method: "GET" })),
+  ];
+
+  for (const probe of probes) {
+    try {
+      const opts = { method: probe.method, credentials: "include" };
+      if (probe.body) {
+        opts.body = probe.body;
+        opts.headers = { "Content-Type": "application/json" };
+      }
+      const resp = await fetch(probe.url, opts);
+      let body = null;
+      try { body = await resp.json(); } catch (_) {}
+      report.api_probes[probe.key] = {
+        status: resp.status,
+        ok: resp.ok,
+        xhs_code: body?.code ?? null,
+        xhs_msg:  body?.msg  || body?.message || null,
+        // 404/461(XHS风控)/999(系统封锁) 均为被拦截信号
+        risk_blocked: resp.status === 404 || resp.status === 461 || resp.status === 999,
+      };
+    } catch (e) {
+      report.api_probes[probe.key] = { error: String(e.message || e) };
+    }
+  }
+
+  // ── 4. 汇总风险等级 ──────────────────────────────────────────
+  const issues = [];
+
+  if (fp.webdriver === true)
+    issues.push({ level: "high", msg: "navigator.webdriver = true，自动化特征已暴露" });
+  if (fp.plugins_count === 0)
+    issues.push({ level: "medium", msg: "navigator.plugins 为空（自动化/无扩展环境）" });
+  if (fp.is_headless_ua)
+    issues.push({ level: "high", msg: `User-Agent 含自动化标志: ${fp.user_agent}` });
+  if (fp.outer_width === 0 || fp.outer_height === 0)
+    issues.push({ level: "medium", msg: `outerWidth/outerHeight = ${fp.outer_width}x${fp.outer_height}，疑似无头模式` });
+  if (fp.webgl_is_swiftshader)
+    issues.push({ level: "high", msg: `WebGL 软件渲染: ${fp.webgl_renderer}（无头特征）` });
+  if (fp.notifications_permission === "denied")
+    issues.push({ level: "low", msg: "通知权限被拒绝（无头浏览器常见特征）" });
+  if (fp.visibility_state !== "visible")
+    issues.push({ level: "medium", msg: `document.visibilityState = "${fp.visibility_state}"（visibilityState 伪装失效）` });
+  if (ps.has_captcha_modal)
+    issues.push({ level: "high", msg: "检测到页面验证码/人机验证弹窗" });
+  if (ps.page_is_404)
+    issues.push({ level: "high", msg: "当前页面为 404 错误页（风控拦截跳转）" });
+  if (ps.page_has_risk_block)
+    issues.push({ level: "high", msg: "检测到风控封锁页面元素" });
+  if (ps.api_failures_on_page.length > 0)
+    issues.push({ level: "medium", msg: `页面已有 ${ps.api_failures_on_page.length} 个 API 请求被风控拦截` });
+  if (ps.state_risk_keys && ps.state_risk_keys.length > 0)
+    issues.push({ level: "high", msg: `__INITIAL_STATE__ 含风控字段: ${ps.state_risk_keys.join(", ")}` });
+
+  for (const [key, probe] of Object.entries(report.api_probes)) {
+    if (probe.risk_blocked)
+      issues.push({ level: "high", msg: `API ${key} 返回风控状态码 ${probe.status}` });
+    else if (probe.xhs_code === 300012 || probe.xhs_code === -9001)
+      issues.push({ level: "high", msg: `API ${key} 返回封号/风控码 ${probe.xhs_code}: ${probe.xhs_msg}` });
+    else if (probe.xhs_code === -1)
+      issues.push({ level: "medium", msg: `API ${key} 返回系统繁忙 (-1): ${probe.xhs_msg}` });
+  }
+
+  report.issues = issues;
+  const high = issues.filter(i => i.level === "high").length;
+  const med  = issues.filter(i => i.level === "medium").length;
+  if (high >= 2)       report.risk_level = "high";
+  else if (high >= 1 || med >= 2) report.risk_level = "medium";
+  else if (med >= 1 || issues.length > 0) report.risk_level = "low";
+  else                 report.risk_level = "safe";
+
+  return report;
 }
 
 // ───────────────────────── Tab 管理 ─────────────────────────

--- a/extension/background.js
+++ b/extension/background.js
@@ -9,6 +9,9 @@
  * - get_cookies: chrome.cookies.getAll
  */
 
+importScripts("netlogger.js");
+netlogInit();
+
 const BRIDGE_URL = "ws://localhost:9333";
 let ws = null;
 
@@ -57,6 +60,25 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
     chrome.storage.session.get("blockEvents", (data) => {
       sendResponse({ events: data.blockEvents || [] });
     });
+    return true;
+  }
+
+  if (msg.type === "NETLOG_GET_ALL") {
+    sendResponse({ entries: netlogGetAll(), enabled: netlogIsEnabled() });
+    return true;
+  }
+  if (msg.type === "NETLOG_CLEAR") {
+    netlogClear();
+    sendResponse({ ok: true });
+    return true;
+  }
+  if (msg.type === "NETLOG_SET_ENABLED") {
+    netlogSetEnabled(msg.enabled);
+    sendResponse({ ok: true, enabled: netlogIsEnabled() });
+    return true;
+  }
+  if (msg.type === "NETLOG_GET_ENABLED") {
+    sendResponse({ enabled: netlogIsEnabled() });
     return true;
   }
 });

--- a/extension/background.js
+++ b/extension/background.js
@@ -163,6 +163,13 @@ async function handleCommand(msg) {
     case "type_text":
       return await cmdTypeTextViaDebugger(params);
 
+    // ── NetLog 风控数据 ──
+    case "get_netlog":
+      return { entries: netlogGetAll(), enabled: netlogIsEnabled() };
+
+    case "get_netlog_enabled":
+      return { enabled: netlogIsEnabled() };
+
     // ── 风控分析 ──
     case "analyze_risk_control":
       return await cmdAnalyzeRiskControl(params);

--- a/extension/background.js
+++ b/extension/background.js
@@ -10,7 +10,7 @@
  */
 
 importScripts("netlogger.js");
-netlogInit();
+netlogInit().catch(e => console.warn("[XHS NetLogger] init failed", e));
 
 const BRIDGE_URL = "ws://localhost:9333";
 let ws = null;

--- a/extension/content.js
+++ b/extension/content.js
@@ -237,17 +237,3 @@ window.addEventListener("message", (e) => {
   }
 });
 
-// 启动时同步 netlog 启用状态到 MAIN world
-function _syncNetlogStatus() {
-  chrome.runtime.sendMessage({ type: "NETLOG_GET_ENABLED" }, (resp) => {
-    window.postMessage({ source: "xhs-netlog-status", enabled: !!resp?.enabled }, "*");
-  });
-}
-_syncNetlogStatus();
-
-// 监听 background 推送的启用状态变化
-chrome.runtime.onMessage.addListener((msg) => {
-  if (msg.type === "NETLOG_ENABLED_CHANGED") {
-    window.postMessage({ source: "xhs-netlog-status", enabled: !!msg.enabled }, "*");
-  }
-});

--- a/extension/content.js
+++ b/extension/content.js
@@ -223,3 +223,31 @@ async function cmdSetFileInput({ selector, files }) {
 function sleep(ms) {
   return new Promise((r) => setTimeout(r, ms));
 }
+
+// ─── NetLog 信号转发 + 启用状态同步 ──────────────────────────────
+
+// MAIN world interceptor → content (postMessage) → background (runtime)
+window.addEventListener("message", (e) => {
+  if (e.source !== window) return;
+  if (e.data?.source === "xhs-netlog-intercept") {
+    chrome.runtime.sendMessage({
+      type: "NETLOG_INTERCEPTOR_ENTRY",
+      payload: e.data,
+    }).catch(() => {});
+  }
+});
+
+// 启动时同步 netlog 启用状态到 MAIN world
+function _syncNetlogStatus() {
+  chrome.runtime.sendMessage({ type: "NETLOG_GET_ENABLED" }, (resp) => {
+    window.postMessage({ source: "xhs-netlog-status", enabled: !!resp?.enabled }, "*");
+  });
+}
+_syncNetlogStatus();
+
+// 监听 background 推送的启用状态变化
+chrome.runtime.onMessage.addListener((msg) => {
+  if (msg.type === "NETLOG_ENABLED_CHANGED") {
+    window.postMessage({ source: "xhs-netlog-status", enabled: !!msg.enabled }, "*");
+  }
+});

--- a/extension/content.js
+++ b/extension/content.js
@@ -4,7 +4,20 @@
  * 接收来自 background.js 的 DOM 操作命令并执行。
  * evaluate / has_element 等需要访问页面 JS 变量的命令由 background.js
  * 通过 chrome.scripting.executeScript(world:"MAIN") 直接处理，不经过这里。
+ *
+ * 同时负责接收来自 interceptor.js（MAIN world）的 postMessage，
+ * 将 404 诊断事件转发给 background.js 存储。
  */
+
+// ── interceptor.js (MAIN world) → background.js 桥接 ────────
+window.addEventListener("message", (e) => {
+  if (e.source !== window) return;
+  if (e.data?.source !== "xhs-interceptor" || e.data?.type !== "BLOCK_EVENT") return;
+  chrome.runtime.sendMessage({ type: "XHS_BLOCK_EVENT", event: e.data.event }).catch(() => {});
+});
+
+// 通知 interceptor.js：content.js 已就绪，可以 flush 排队的事件
+window.postMessage({ source: "xhs-content-ready" }, "*");
 
 chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   handleDomCommand(msg.method, msg.params || {})

--- a/extension/interceptor.js
+++ b/extension/interceptor.js
@@ -1,0 +1,409 @@
+/**
+ * XHS 404 诊断拦截器 — MAIN world, document_start
+ *
+ * 在小红书页面 JS 加载之前包裹原生 fetch / XMLHttpRequest，
+ * 捕获所有返回 404 / 461 / 403 / 999 的请求的完整上下文，
+ * 进行根因分析后通过 window.postMessage 发送给 content script。
+ *
+ * 诊断覆盖：
+ *   - xsec_token 缺失 / 绑定失效
+ *   - xs 签名缺失 / 无效
+ *   - web_session 失效（未登录）
+ *   - IP / 账号级封禁
+ *   - 页面渲染 404（HTTP 200 但内容被屏蔽）
+ */
+
+(function () {
+  "use strict";
+
+  const BLOCKED = new Set([404, 461, 403, 999]);
+  const XHS_API = /xiaohongshu\.com\/api\//;
+
+  // ── Cookie 快照 ──────────────────────────────────────────────
+
+  function captureCookies() {
+    const map = {};
+    for (const part of document.cookie.split(";")) {
+      const idx = part.indexOf("=");
+      if (idx < 0) continue;
+      const k = part.slice(0, idx).trim();
+      const v = part.slice(idx + 1).trim();
+      map[k] = v;
+    }
+    return {
+      has_a1:          "a1" in map,
+      has_web_session: "web_session" in map,
+      has_webId:       "webId" in map,
+      has_gid:         "gid" in map,
+      // 部分预览（不暴露完整 token）
+      a1_preview:          map["a1"]          ? map["a1"].slice(0, 12)          + "…" : null,
+      web_session_preview: map["web_session"] ? map["web_session"].slice(0, 10) + "…" : null,
+    };
+  }
+
+  // ── URL 解析 ─────────────────────────────────────────────────
+
+  function urlParam(url, key) {
+    try { return new URL(url).searchParams.get(key); } catch (_) { return null; }
+  }
+
+  function isApiUrl(url) { return XHS_API.test(url); }
+
+  // ── 根因分析 ─────────────────────────────────────────────────
+
+  function diagnose(status, url, headers, cookies) {
+    const xsecToken  = urlParam(url, "xsec_token");
+    const xsecSource = urlParam(url, "xsec_source");
+    const hasXs  = !!(headers["xs"] || headers["X-S"] || headers["x-s"]);
+    const hasXt  = !!(headers["xt"] || headers["X-T"] || headers["x-t"]);
+    const isPage = !isApiUrl(url);
+
+    // ── 999：系统级封禁 ──────────────────────────────────────
+    if (status === 999) {
+      return {
+        root_cause: "账号 / IP 被系统级封禁（HTTP 999）",
+        cause_category: "account_block",
+        detail:
+          "小红书用 HTTP 999 标记被彻底封禁的账号或 IP 段，" +
+          "所有请求无论携带什么凭证均被拒绝。需更换 IP 或重新注册账号。",
+        confidence: "high",
+        how_xhs_decides:
+          "服务端在路由层维护封禁名单（IP CIDR + userId），命中即返回 999，不经业务逻辑。",
+      };
+    }
+
+    // ── 403：WAF / 防火墙 ────────────────────────────────────
+    if (status === 403) {
+      return {
+        root_cause: "请求被 WAF / 前置防火墙拦截",
+        cause_category: "ip_block",
+        detail:
+          "HTTP 403 来自小红书的 WAF 层（非业务层），" +
+          "常见触发条件：IP 信誉分过低、User-Agent 异常、请求速率超阈值、" +
+          "或请求头特征命中自动化规则。",
+        confidence: "high",
+        how_xhs_decides:
+          "WAF 对每个请求计算特征向量：IP 信誉 × UA 合规性 × 请求间隔 × 头部完整性。" +
+          "超过风险阈值时直接返回 403，不转发给后端。",
+      };
+    }
+
+    // ── 461：签名问题 ────────────────────────────────────────
+    if (status === 461) {
+      if (!hasXs) {
+        return {
+          root_cause: "xs 请求签名完全缺失",
+          cause_category: "signature",
+          detail:
+            "HTTP 461 是小红书专用的"签名缺失"状态码。" +
+            "所有 /api/ 接口均要求 xs header（HMAC 签名），未携带时直接返回 461。",
+          confidence: "high",
+          how_xhs_decides:
+            "服务端在 API 网关层检查 xs header 是否存在。" +
+            "xs = HMAC(url_path + body_hash + timestamp, device_key)，" +
+            "缺失 → 461，存在但验签失败 → 也是 461（但 detail 不同）。",
+        };
+      }
+      return {
+        root_cause: `xs 签名存在但验证失败${hasXt ? "" : "（xt 时间戳头也缺失）"}`,
+        cause_category: "signature",
+        detail:
+          "xs header 已附加，但服务端 HMAC 验证未通过。" +
+          "可能原因：\n" +
+          "  1. 签名算法版本过旧（XHS 定期更新 xs 算法，v1→v2→v3…）\n" +
+          "  2. device_id 与 a1 cookie 不对应（签名密钥绑定设备）\n" +
+          `  3. xt 时间戳偏差超出允许窗口（±5 分钟）${!hasXt ? "，且 xt 头缺失" : ""}`,
+        confidence: "high",
+        how_xhs_decides:
+          "服务端用从 a1 cookie 推导的 device_key 重新计算 HMAC，" +
+          "对比请求中的 xs 值；同时校验 xt 时间戳与服务器时钟差是否在容忍窗口内。",
+      };
+    }
+
+    // ── 404：多种场景 ────────────────────────────────────────
+
+    // 页面级 404（非 API）
+    if (isPage) {
+      if (!xsecToken) {
+        return {
+          root_cause: "xsec_token 缺失——直接构造 URL 访问",
+          cause_category: "token",
+          detail:
+            "小红书笔记 / 用户主页 URL 必须携带 xsec_token 参数，" +
+            "否则服务端直接返回 404（故意用 404 而非 403，迷惑爬虫以为内容不存在）。\n\n" +
+            "正确获取方式：从搜索结果 / 推荐流 / 分享链接中提取，不可手动构造。",
+          confidence: "high",
+          how_xhs_decides:
+            "服务端对所有笔记详情请求校验 xsec_token 签名；" +
+            "token = HMAC(noteId + sessionContext, serverKey)，缺失直接 404。",
+        };
+      }
+      if (!cookies.has_web_session) {
+        return {
+          root_cause: "xsec_token 有效，但 web_session cookie 不存在（未登录 / session 失效）",
+          cause_category: "session",
+          detail:
+            "xsec_token 参数存在，但 web_session cookie 缺失或已过期。" +
+            "服务端绑定验证：token 必须与颁发时的 session 匹配，" +
+            "session 失效后 token 同步失效，返回 404（而非重定向到登录页，这是故意的）。",
+          confidence: "high",
+          how_xhs_decides:
+            "服务端将 xsec_token 与 web_session 绑定存储；" +
+            "请求时查 session 是否存在，不存在则 token 无法解密 → 404。",
+        };
+      }
+      return {
+        root_cause: `xsec_token 与当前 session / IP 绑定验证失败（来源: ${xsecSource || "未知"}）`,
+        cause_category: "token",
+        detail:
+          "xsec_token 和 web_session 均存在，但服务端绑定验证失败。\n" +
+          "可能原因：\n" +
+          "  1. token 是从其他账号获取的（token 绑定颁发时的 userId）\n" +
+          "  2. token 已超过有效期（通常数小时到 1 天）\n" +
+          "  3. IP 变化触发服务端将 token 标记为可疑\n" +
+          `  4. xsec_source="${xsecSource}" 来源类型不符（如 token 从 search 获取却用于 profile 页）`,
+        confidence: "medium",
+        how_xhs_decides:
+          "服务端用 serverKey 解密 xsec_token，提取 {noteId, userId, source, ts, ipHash}，" +
+          "逐字段与当前请求对比：任一不符则 404。",
+      };
+    }
+
+    // API 级 404
+    if (!cookies.has_web_session) {
+      return {
+        root_cause: "API 请求未携带有效 session（未登录）",
+        cause_category: "session",
+        detail:
+          "API 端点在 web_session 不存在时返回 404（而非 401），" +
+          "这是小红书对未登录访问私有 API 的有意混淆处理。",
+        confidence: "high",
+        how_xhs_decides:
+          "API 网关在 session 校验失败时根据端点配置选择响应码：" +
+          "公开 API 返回空数据，私有 API 直接返回 404 以阻止枚举。",
+      };
+    }
+    if (!hasXs) {
+      return {
+        root_cause: "此 API 端点在签名缺失时返回 404（比 461 更严格的端点）",
+        cause_category: "signature",
+        detail:
+          "部分高敏感 API 端点（通常是读取用户隐私数据类）在签名缺失时直接返回 404 而非 461，" +
+          "使爬虫难以区分"不存在"和"无权访问"。",
+        confidence: "medium",
+        how_xhs_decides:
+          "API 网关根据端点安全级别配置响应码策略：" +
+          "普通端点 → 461，高敏感端点 → 404，以防止端点存在性探测。",
+      };
+    }
+    return {
+      root_cause: "IP 或账号维度风控封禁（所有凭证均有效但仍 404）",
+      cause_category: "risk_control",
+      detail:
+        "web_session、xs 签名、xsec_token 均存在且通过格式校验，" +
+        "但服务端仍返回 404。这是最典型的风控特征：\n" +
+        "  - IP 风控：当前 IP 在短时间内请求量超过阈值，被标记后所有内容请求返回 404\n" +
+        "  - 账号风控：账号行为评分低于阈值（过于机械的操作模式），内容访问被限流\n" +
+        "  - 设备指纹风控：浏览器指纹被识别为自动化环境",
+      confidence: "high",
+      how_xhs_decides:
+        "服务端对每个 {IP, userId, deviceId} 三元组维护实时行为评分：" +
+        "请求间隔方差、路径分布、滚动事件频率等，评分低于阈值时对特定内容返回 404，" +
+        "但登录态保持正常（避免用户察觉），造成"内容消失"的假象。",
+    };
+  }
+
+  // ── 构造完整诊断事件 ─────────────────────────────────────────
+
+  function buildEvent(url, method, status, headers, extra) {
+    const cookies = captureCookies();
+    const diag    = diagnose(status, url, headers, cookies);
+    return {
+      id:        `${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
+      timestamp: new Date().toISOString(),
+      url,
+      method:    method.toUpperCase(),
+      status,
+      pageUrl:   window.location.href,
+      request: {
+        xsec_token:    urlParam(url, "xsec_token"),
+        xsec_source:   urlParam(url, "xsec_source"),
+        has_xs:        !!(headers["xs"]      || headers["X-S"]           || headers["x-s"]),
+        has_xt:        !!(headers["xt"]      || headers["X-T"]           || headers["x-t"]),
+        has_referer:   !!(headers["referer"] || headers["Referer"]),
+        sec_fetch_site: headers["Sec-Fetch-Site"] || headers["sec-fetch-site"] || null,
+        content_type:   headers["Content-Type"]   || headers["content-type"]   || null,
+      },
+      cookies,
+      diagnosis: diag,
+      ...(extra || {}),
+    };
+  }
+
+  // 消息队列：content.js 在 document_idle 才就绪，早于此时的事件需要排队
+  const _pendingEvents = [];
+  let _contentReady = false;
+
+  window.addEventListener("message", (e) => {
+    if (e.data?.source === "xhs-interceptor-ack") _contentReady = true;
+  });
+
+  function emit(event) {
+    if (_contentReady) {
+      window.postMessage({ source: "xhs-interceptor", type: "BLOCK_EVENT", event }, "*");
+    } else {
+      _pendingEvents.push(event);
+    }
+  }
+
+  function flushPending() {
+    _contentReady = true;
+    for (const ev of _pendingEvents) {
+      window.postMessage({ source: "xhs-interceptor", type: "BLOCK_EVENT", event: ev }, "*");
+    }
+    _pendingEvents.length = 0;
+  }
+
+  // content.js 就绪后会发 xhs-interceptor-ready 消息，或 500ms 后强制 flush
+  window.addEventListener("message", (e) => {
+    if (e.data?.source === "xhs-content-ready") flushPending();
+  });
+  setTimeout(flushPending, 800);
+
+  // ── fetch 拦截 ───────────────────────────────────────────────
+
+  const _fetch = window.fetch;
+  window.fetch = async function (input, init) {
+    const url    = typeof input === "string" ? input : input?.url || String(input);
+    const method = init?.method || "GET";
+    const headers = {};
+    if (init?.headers) {
+      if (init.headers instanceof Headers) {
+        init.headers.forEach((v, k) => { headers[k] = v; });
+      } else {
+        Object.assign(headers, init.headers);
+      }
+    }
+
+    const resp = await _fetch.call(this, input, init);
+
+    if (BLOCKED.has(resp.status) && (isApiUrl(url) || url.includes("xiaohongshu.com"))) {
+      emit(buildEvent(url, method, resp.status, headers, { intercept_type: "fetch" }));
+    }
+    return resp;
+  };
+
+  // ── XMLHttpRequest 拦截 ──────────────────────────────────────
+
+  const _xhrOpen      = XMLHttpRequest.prototype.open;
+  const _xhrSend      = XMLHttpRequest.prototype.send;
+  const _xhrSetHeader = XMLHttpRequest.prototype.setRequestHeader;
+
+  XMLHttpRequest.prototype.open = function (method, url) {
+    this.__i_method  = method;
+    this.__i_url     = url;
+    this.__i_headers = {};
+    return _xhrOpen.apply(this, arguments);
+  };
+
+  XMLHttpRequest.prototype.setRequestHeader = function (name, value) {
+    if (this.__i_headers) this.__i_headers[name] = value;
+    return _xhrSetHeader.apply(this, arguments);
+  };
+
+  XMLHttpRequest.prototype.send = function () {
+    this.addEventListener("loadend", () => {
+      const url = this.__i_url || "";
+      if (BLOCKED.has(this.status) && (isApiUrl(url) || url.includes("xiaohongshu.com"))) {
+        emit(buildEvent(url, this.__i_method || "GET", this.status, this.__i_headers || {}, {
+          intercept_type: "xhr",
+        }));
+      }
+    });
+    return _xhrSend.apply(this, arguments);
+  };
+
+  // ── 页面渲染级 404 检测（HTTP 200 但内容被屏蔽）───────────────
+
+  function checkPageRender404() {
+    const url = window.location.href;
+    if (!url.includes("xiaohongshu.com")) return;
+
+    let triggered = false;
+    let pageErrorDetail = null;
+
+    // 检查 __INITIAL_STATE__ 中的错误标记
+    try {
+      const s = window.__INITIAL_STATE__;
+      if (s) {
+        if (s.pageError || s.errorCode || s.forbidden) {
+          triggered = true;
+          pageErrorDetail = {
+            pageError:  s.pageError  || null,
+            errorCode:  s.errorCode  || null,
+            forbidden:  s.forbidden  || null,
+          };
+        }
+      }
+    } catch (_) {}
+
+    // 检查 DOM
+    if (!triggered) {
+      const is404Dom = document.title.includes("404") ||
+        !!document.querySelector('[class*="not-found"], [class*="error-page"], [class*="page-not-found"]');
+      if (is404Dom) triggered = true;
+    }
+
+    if (triggered) {
+      const cookies = captureCookies();
+      const xsecToken = urlParam(url, "xsec_token");
+      emit({
+        id:        `${Date.now()}_render`,
+        timestamp: new Date().toISOString(),
+        url,
+        method:    "GET",
+        status:    "200→404",  // HTTP 成功但渲染出 404
+        pageUrl:   url,
+        intercept_type: "page_render",
+        request: {
+          xsec_token:  xsecToken,
+          xsec_source: urlParam(url, "xsec_source"),
+          has_xs:      false,
+          has_xt:      false,
+          has_referer: !!document.referrer,
+          sec_fetch_site: null,
+          content_type:   null,
+        },
+        cookies,
+        page_error_state: pageErrorDetail,
+        diagnosis: xsecToken
+          ? {
+              root_cause: "内容已被删除 / 下架，或账号无权访问",
+              cause_category: "content_unavailable",
+              detail:
+                "页面返回 HTTP 200 但渲染为 404 错误页，且 xsec_token 存在（说明不是 token 问题）。\n" +
+                "这表示内容本身已不可用：笔记被作者删除、被平台下架、或当前账号被限制访问该内容。",
+              confidence: "medium",
+              how_xhs_decides:
+                "XHS 前端（Vue/React 应用）在拿到服务端数据后检查 note.status 字段，" +
+                "若为 banned/deleted/invisible 则渲染 404 组件，HTTP 状态码仍是 200。",
+            }
+          : {
+              root_cause: "xsec_token 缺失，服务端返回空内容，前端渲染 404",
+              cause_category: "token",
+              detail: "URL 不含 xsec_token，服务端返回了"内容不存在"的数据包，前端据此渲染 404 页面。",
+              confidence: "high",
+              how_xhs_decides:
+                "同页面级 404 逻辑：token 缺失 → 服务端返回空 note 数据 → 前端渲染 notFound 组件。",
+            },
+      });
+    }
+  }
+
+  // 在 DOMContentLoaded 之后检查页面状态
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", () => setTimeout(checkPageRender404, 500));
+  } else {
+    setTimeout(checkPageRender404, 500);
+  }
+})();

--- a/extension/interceptor.js
+++ b/extension/interceptor.js
@@ -97,7 +97,7 @@
           root_cause: "xs 请求签名完全缺失",
           cause_category: "signature",
           detail:
-            "HTTP 461 是小红书专用的"签名缺失"状态码。" +
+            "HTTP 461 是小红书专用的「签名缺失」状态码。" +
             "所有 /api/ 接口均要求 xs header（HMAC 签名），未携带时直接返回 461。",
           confidence: "high",
           how_xhs_decides:
@@ -191,7 +191,7 @@
         cause_category: "signature",
         detail:
           "部分高敏感 API 端点（通常是读取用户隐私数据类）在签名缺失时直接返回 404 而非 461，" +
-          "使爬虫难以区分"不存在"和"无权访问"。",
+          "使爬虫难以区分「不存在」和「无权访问」。",
         confidence: "medium",
         how_xhs_decides:
           "API 网关根据端点安全级别配置响应码策略：" +
@@ -211,7 +211,7 @@
       how_xhs_decides:
         "服务端对每个 {IP, userId, deviceId} 三元组维护实时行为评分：" +
         "请求间隔方差、路径分布、滚动事件频率等，评分低于阈值时对特定内容返回 404，" +
-        "但登录态保持正常（避免用户察觉），造成"内容消失"的假象。",
+        "但登录态保持正常（避免用户察觉），造成「内容消失」的假象。",
     };
   }
 
@@ -477,7 +477,7 @@
           : {
               root_cause: "xsec_token 缺失，服务端返回空内容，前端渲染 404",
               cause_category: "token",
-              detail: "URL 不含 xsec_token，服务端返回了"内容不存在"的数据包，前端据此渲染 404 页面。",
+              detail: "URL 不含 xsec_token，服务端返回了「内容不存在」的数据包，前端据此渲染 404 页面。",
               confidence: "high",
               how_xhs_decides:
                 "同页面级 404 逻辑：token 缺失 → 服务端返回空 note 数据 → 前端渲染 notFound 组件。",

--- a/extension/interceptor.js
+++ b/extension/interceptor.js
@@ -19,6 +19,17 @@
   const BLOCKED = new Set([404, 461, 403, 999]);
   const XHS_API = /xiaohongshu\.com\/api\//;
 
+  let _netlogEnabled = false;
+  const RESP_BODY_MAX = 4096;
+
+  // 通过 storage 同步 netlog 启用状态（MAIN world 不能直接读 chrome.storage）
+  // content.js 监听 storage.local 变化，postMessage 给我们
+  window.addEventListener("message", (e) => {
+    if (e.data?.source === "xhs-netlog-status") {
+      _netlogEnabled = !!e.data.enabled;
+    }
+  });
+
   // ── Cookie 快照 ──────────────────────────────────────────────
 
   function captureCookies() {
@@ -287,9 +298,31 @@
 
     const resp = await _fetch.call(this, input, init);
 
+    // 现有 BLOCKED 诊断保持不变
     if (BLOCKED.has(resp.status) && (isApiUrl(url) || url.includes("xiaohongshu.com"))) {
       emit(buildEvent(url, method, resp.status, headers, { intercept_type: "fetch" }));
     }
+
+    // NetLog 全量记录（仅启用时）
+    if (_netlogEnabled && url.includes("xiaohongshu.com")) {
+      let respBody = null;
+      try {
+        const clone = resp.clone();
+        const text = await clone.text();
+        respBody = text.length > RESP_BODY_MAX ? text.slice(0, RESP_BODY_MAX) + "…[cut]" : text;
+      } catch (_) { respBody = "[unreadable]"; }
+
+      window.postMessage({
+        source: "xhs-netlog-intercept",
+        method,
+        url,
+        status: resp.status,
+        reqHeaders: headers,
+        respBody,
+        ts: Date.now(),
+      }, "*");
+    }
+
     return resp;
   };
 
@@ -314,10 +347,31 @@
   XMLHttpRequest.prototype.send = function () {
     this.addEventListener("loadend", () => {
       const url = this.__i_url || "";
+
+      // 现有 BLOCKED 诊断保持不变
       if (BLOCKED.has(this.status) && (isApiUrl(url) || url.includes("xiaohongshu.com"))) {
         emit(buildEvent(url, this.__i_method || "GET", this.status, this.__i_headers || {}, {
           intercept_type: "xhr",
         }));
+      }
+
+      // NetLog 全量记录
+      if (_netlogEnabled && url.includes("xiaohongshu.com")) {
+        let respBody = null;
+        try {
+          const t = this.responseText || "";
+          respBody = t.length > RESP_BODY_MAX ? t.slice(0, RESP_BODY_MAX) + "…[cut]" : t;
+        } catch (_) { respBody = "[unreadable]"; }
+
+        window.postMessage({
+          source: "xhs-netlog-intercept",
+          method: this.__i_method || "GET",
+          url,
+          status: this.status,
+          reqHeaders: this.__i_headers || {},
+          respBody,
+          ts: Date.now(),
+        }, "*");
       }
     });
     return _xhrSend.apply(this, arguments);

--- a/extension/interceptor.js
+++ b/extension/interceptor.js
@@ -272,6 +272,47 @@
   });
   setTimeout(flushPending, 800);
 
+  // ── Response.prototype hook ─────────────────────────────────
+  // XHS 在主 bundle 加载时会用混淆代码覆盖 window.fetch，绕过我们的 fetch hook。
+  // 改为 hook Response.prototype.text/.json：任何代码读响应体都必须调这两个之一，
+  // 包括 XHS 的 wrapper 链最终也得到 Response 对象。
+
+  const _respText = Response.prototype.text;
+  const _respJson = Response.prototype.json;
+
+  function _netlogReportResp(url, status, body) {
+    if (!url || !url.includes("xiaohongshu.com")) return;
+    let truncated = body;
+    if (typeof body === "string" && body.length > RESP_BODY_MAX) {
+      truncated = body.slice(0, RESP_BODY_MAX) + "…[cut]";
+    }
+    try {
+      window.postMessage({
+        source: "xhs-netlog-intercept",
+        method: "?",                // Response 对象拿不到原 method
+        url,
+        status,
+        reqHeaders: {},
+        respBody: truncated,
+        ts: Date.now(),
+      }, "*");
+    } catch (_) {}
+  }
+
+  Response.prototype.text = async function() {
+    const body = await _respText.call(this);
+    _netlogReportResp(this.url, this.status, body);
+    return body;
+  };
+
+  Response.prototype.json = async function() {
+    const data = await _respJson.call(this);
+    try {
+      _netlogReportResp(this.url, this.status, JSON.stringify(data));
+    } catch (_) {}
+    return data;
+  };
+
   // ── fetch 拦截 ───────────────────────────────────────────────
 
   const _fetch = window.fetch;

--- a/extension/interceptor.js
+++ b/extension/interceptor.js
@@ -19,16 +19,7 @@
   const BLOCKED = new Set([404, 461, 403, 999]);
   const XHS_API = /xiaohongshu\.com\/api\//;
 
-  let _netlogEnabled = false;
   const RESP_BODY_MAX = 4096;
-
-  // 通过 storage 同步 netlog 启用状态（MAIN world 不能直接读 chrome.storage）
-  // content.js 监听 storage.local 变化，postMessage 给我们
-  window.addEventListener("message", (e) => {
-    if (e.data?.source === "xhs-netlog-status") {
-      _netlogEnabled = !!e.data.enabled;
-    }
-  });
 
   // ── Cookie 快照 ──────────────────────────────────────────────
 
@@ -303,8 +294,8 @@
       emit(buildEvent(url, method, resp.status, headers, { intercept_type: "fetch" }));
     }
 
-    // NetLog 全量记录（仅启用时）
-    if (_netlogEnabled && url.includes("xiaohongshu.com")) {
+    // NetLog 全量记录（background 单点过滤 _netEnabled）
+    if (url.includes("xiaohongshu.com")) {
       let respBody = null;
       try {
         const clone = resp.clone();
@@ -355,8 +346,8 @@
         }));
       }
 
-      // NetLog 全量记录
-      if (_netlogEnabled && url.includes("xiaohongshu.com")) {
+      // NetLog 全量记录（background 单点过滤 _netEnabled）
+      if (url.includes("xiaohongshu.com")) {
         let respBody = null;
         try {
           const t = this.responseText || "";

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -8,7 +8,9 @@
     "cookies",
     "scripting",
     "alarms",
-    "debugger"
+    "debugger",
+    "storage",
+    "webRequest"
   ],
   "host_permissions": [
     "https://www.xiaohongshu.com/*",
@@ -19,7 +21,21 @@
   "background": {
     "service_worker": "background.js"
   },
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "XHS Bridge"
+  },
   "content_scripts": [
+    {
+      "matches": [
+        "https://www.xiaohongshu.com/*",
+        "https://xiaohongshu.com/*",
+        "https://creator.xiaohongshu.com/*"
+      ],
+      "js": ["interceptor.js"],
+      "run_at": "document_start",
+      "world": "MAIN"
+    },
     {
       "matches": [
         "https://www.xiaohongshu.com/*",

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -13,9 +13,8 @@
     "webRequest"
   ],
   "host_permissions": [
-    "https://www.xiaohongshu.com/*",
+    "https://*.xiaohongshu.com/*",
     "https://xiaohongshu.com/*",
-    "https://creator.xiaohongshu.com/*",
     "ws://localhost/*"
   ],
   "background": {

--- a/extension/netlogger.js
+++ b/extension/netlogger.js
@@ -61,3 +61,212 @@ function _netlogPush(entry) {
   // 通知 popup 增量
   chrome.runtime.sendMessage({ type: "NETLOG_ENTRY_ADDED", entry }).catch(() => {});
 }
+
+// ─── Step 3.1: header 白名单 + cookie 工具 ───────────────────────────────────
+
+const NETLOG_REQ_HEADER_WHITELIST = new Set([
+  "xs", "xt", "x-s-common", "x-t", "x-mns-platform",
+  "sec-fetch-site", "sec-fetch-mode", "sec-fetch-dest", "sec-fetch-user",
+  "referer", "origin", "user-agent",
+  "content-type", "accept", "accept-language",
+]);
+
+const NETLOG_RESP_HEADER_WHITELIST = new Set([
+  "location", "set-cookie", "cache-control", "x-request-id",
+  "content-type", "server", "x-application-context",
+]);
+
+const NETLOG_COOKIE_KEYS = ["a1", "web_session", "webId", "gid"];
+
+const NETLOG_SKIP_TYPES = new Set(["image", "font", "stylesheet", "media"]);
+
+function _filterHeaders(rawHeaders, whitelist) {
+  const out = {};
+  if (!rawHeaders) return out;
+  for (const h of rawHeaders) {
+    const k = h.name.toLowerCase();
+    if (whitelist.has(k)) {
+      // set-cookie 可能多个值，累加
+      if (k === "set-cookie" && out[k]) out[k] += "\n" + h.value;
+      else out[k] = h.value;
+    }
+  }
+  return out;
+}
+
+function _parseCookieHeader(cookieStr) {
+  const map = {};
+  if (!cookieStr) return map;
+  for (const part of cookieStr.split(";")) {
+    const i = part.indexOf("=");
+    if (i < 0) continue;
+    map[part.slice(0, i).trim()] = part.slice(i + 1).trim();
+  }
+  return map;
+}
+
+function _extractReqBody(requestBody) {
+  if (!requestBody) return null;
+  if (requestBody.raw && requestBody.raw[0] && requestBody.raw[0].bytes) {
+    try {
+      return new TextDecoder().decode(requestBody.raw[0].bytes).slice(0, NETLOG_REQBODY_MAX);
+    } catch (_) {
+      return "[binary " + requestBody.raw[0].bytes.byteLength + "B]";
+    }
+  }
+  if (requestBody.formData) {
+    try {
+      return JSON.stringify(requestBody.formData).slice(0, NETLOG_REQBODY_MAX);
+    } catch (_) { return "[formData]"; }
+  }
+  return null;
+}
+
+function _tsLabel(ts) {
+  const d = new Date(ts);
+  return String(d.getHours()).padStart(2, "0") + ":" +
+         String(d.getMinutes()).padStart(2, "0") + ":" +
+         String(d.getSeconds()).padStart(2, "0") + "." +
+         String(d.getMilliseconds()).padStart(3, "0");
+}
+
+// ─── Step 3.2: onBeforeRequest（拿 reqBody bytes） ────────────────────────────
+
+const NETLOG_URL_FILTER = {
+  urls: ["<all_urls>"],
+};
+
+chrome.webRequest.onBeforeRequest.addListener(
+  (details) => {
+    if (!_netEnabled) return;
+    if (NETLOG_SKIP_TYPES.has(details.type)) return;
+
+    let host = "";
+    try { host = new URL(details.url).host; } catch (_) {}
+
+    _netPending.set(details.requestId, {
+      id: `${details.timeStamp}_${details.requestId}`,
+      requestId: details.requestId,
+      ts: details.timeStamp,
+      tsLabel: _tsLabel(details.timeStamp),
+      method: details.method,
+      url: details.url,
+      host,
+      path: (() => { try { const u = new URL(details.url); return u.pathname + (u.search || ""); } catch (_) { return details.url; } })(),
+      resourceType: details.type,
+      tabId: details.tabId,
+      reqHeaders: {},
+      reqBody: _extractReqBody(details.requestBody),
+      reqFingerprint: null,
+      status: 0,
+      statusLine: "",
+      respHeaders: {},
+      respBody: null,
+      setCookie: null,
+      duration_ms: 0,
+      err: null,
+      category: "other",
+      signals: [],
+      cookieDiff: null,
+      redirectTo: null,
+      errorCode: null,
+      _t0: Date.now(),
+    });
+  },
+  NETLOG_URL_FILTER,
+  ["requestBody"],
+);
+
+// ─── Step 3.3: onSendHeaders（拿请求头 + cookie 指纹） ────────────────────────
+
+chrome.webRequest.onSendHeaders.addListener(
+  (details) => {
+    if (!_netEnabled) return;
+    const entry = _netPending.get(details.requestId);
+    if (!entry) return;
+
+    entry.reqHeaders = _filterHeaders(details.requestHeaders, NETLOG_REQ_HEADER_WHITELIST);
+
+    const cookieStr = (details.requestHeaders || []).find(h => h.name.toLowerCase() === "cookie")?.value || "";
+    const cookieMap = _parseCookieHeader(cookieStr);
+    const ua = entry.reqHeaders["user-agent"] || "";
+    entry.reqFingerprint = {
+      has_xs:        !!entry.reqHeaders["xs"],
+      has_xt:        !!entry.reqHeaders["xt"],
+      has_xsCommon:  !!entry.reqHeaders["x-s-common"],
+      sec_fetch_site: entry.reqHeaders["sec-fetch-site"] || null,
+      sec_fetch_mode: entry.reqHeaders["sec-fetch-mode"] || null,
+      referer:        entry.reqHeaders["referer"] || null,
+      origin:         entry.reqHeaders["origin"] || null,
+      ua_prefix:      ua.slice(0, 80),
+      cookie: {
+        has_a1:              "a1" in cookieMap,
+        has_web_session:     "web_session" in cookieMap,
+        has_webId:           "webId" in cookieMap,
+        has_gid:             "gid" in cookieMap,
+        a1_preview:          cookieMap["a1"]          ? cookieMap["a1"].slice(0, 12)          + "…" : null,
+        web_session_preview: cookieMap["web_session"] ? cookieMap["web_session"].slice(0, 10) + "…" : null,
+      },
+    };
+  },
+  NETLOG_URL_FILTER,
+  ["requestHeaders", "extraHeaders"],
+);
+
+// ─── Step 3.4: onHeadersReceived（拿响应头 / 状态 / set-cookie） ──────────────
+
+chrome.webRequest.onHeadersReceived.addListener(
+  (details) => {
+    if (!_netEnabled) return;
+    const entry = _netPending.get(details.requestId);
+    if (!entry) return;
+
+    entry.status = details.statusCode;
+    entry.statusLine = (details.statusLine || "").replace(/^HTTP\/[\d.]+\s*/, "");
+    entry.respHeaders = _filterHeaders(details.responseHeaders, NETLOG_RESP_HEADER_WHITELIST);
+
+    if (entry.respHeaders["set-cookie"]) {
+      entry.setCookie = entry.respHeaders["set-cookie"]
+        .split("\n")
+        .map(s => {
+          const i = s.indexOf("=");
+          return i > 0 ? s.slice(0, i).trim() : s.trim();
+        });
+    }
+
+    if (details.statusCode === 301 || details.statusCode === 302) {
+      entry.redirectTo = entry.respHeaders["location"] || null;
+      if (entry.redirectTo) {
+        try {
+          const loc = new URL(entry.redirectTo, details.url);
+          entry.errorCode = loc.searchParams.get("error_code");
+        } catch (_) {}
+      }
+    }
+  },
+  NETLOG_URL_FILTER,
+  ["responseHeaders", "extraHeaders"],
+);
+
+// ─── Step 3.5: onCompleted + onErrorOccurred（finalize 入栈） ─────────────────
+
+function _netlogFinalize(details, isError) {
+  if (!_netEnabled) return;
+  const entry = _netPending.get(details.requestId);
+  _netPending.delete(details.requestId);
+  if (!entry) return;
+  entry.duration_ms = Date.now() - entry._t0;
+  delete entry._t0;
+  if (isError) entry.err = details.error || "network_error";
+  // 分类逻辑由后续 task 5 接入
+  _netlogPush(entry);
+}
+
+chrome.webRequest.onCompleted.addListener(
+  (d) => _netlogFinalize(d, false),
+  NETLOG_URL_FILTER,
+);
+chrome.webRequest.onErrorOccurred.addListener(
+  (d) => _netlogFinalize(d, true),
+  NETLOG_URL_FILTER,
+);

--- a/extension/netlogger.js
+++ b/extension/netlogger.js
@@ -297,7 +297,8 @@ function netlogIngestInterceptor(payload) {
   for (let i = _netBuffer.length - 1; i >= 0; i--) {
     const e = _netBuffer[i];
     if (payload.ts - e.ts > NETLOG_INTERCEPTOR_WINDOW_MS) break;
-    if (e.method === payload.method && _netlogUrlMatch(e.url, payload.url) && !e.respBody) {
+    const methodOk = payload.method === "?" || e.method === payload.method;
+    if (methodOk && _netlogUrlMatch(e.url, payload.url) && !e.respBody) {
       e.respBody = payload.respBody;
       // 合并 interceptor 头（webRequest 拿不到的应用层头）
       for (const [k, v] of Object.entries(payload.reqHeaders || {})) {
@@ -314,7 +315,7 @@ function netlogIngestInterceptor(payload) {
     requestId: "",
     ts: payload.ts,
     tsLabel: _tsLabel(payload.ts),
-    method: payload.method,
+    method: payload.method === "?" ? "UNKNOWN" : payload.method,
     url: payload.url,
     host: (() => { try { return new URL(payload.url).host; } catch (_) { return ""; } })(),
     path: (() => { try { const u = new URL(payload.url); return u.pathname + (u.search || ""); } catch (_) { return payload.url; } })(),

--- a/extension/netlogger.js
+++ b/extension/netlogger.js
@@ -1,0 +1,63 @@
+/**
+ * XHS NetLogger - 全量请求监听 + 检测维度归类
+ *
+ * 仅在 chrome.storage.local.netlogEnabled === true 时记录。
+ * 环形缓冲 500 条；每 10 条 / 关键事件触发写入 storage。
+ * 详细设计：docs/superpowers/specs/2026-05-19-xhs-netlogger-design.md
+ */
+
+const NETLOG_MAX_ENTRIES   = 500;
+const NETLOG_REQBODY_MAX   = 2048;
+const NETLOG_RESPBODY_MAX  = 4096;
+const NETLOG_FLUSH_EVERY_N = 10;
+const NETLOG_STORAGE_KEY   = "netLog";
+const NETLOG_ENABLED_KEY   = "netlogEnabled";
+
+const _netBuffer = [];
+const _netPending = new Map();            // requestId → 半成品 entry（跨 webRequest 4 阶段）
+let _netEnabled = false;
+let _netFlushCounter = 0;
+let _lastHostCookies = new Map();         // host → Set<cookie name> for cookieDiff
+
+function netlogIsEnabled() { return _netEnabled; }
+
+function netlogSetEnabled(v) {
+  _netEnabled = !!v;
+  chrome.storage.local.set({ [NETLOG_ENABLED_KEY]: _netEnabled });
+  if (!_netEnabled) _netPending.clear();
+}
+
+async function netlogInit() {
+  const data = await chrome.storage.local.get([NETLOG_ENABLED_KEY, NETLOG_STORAGE_KEY]);
+  _netEnabled = !!data[NETLOG_ENABLED_KEY];
+  if (Array.isArray(data[NETLOG_STORAGE_KEY])) {
+    _netBuffer.push(...data[NETLOG_STORAGE_KEY].slice(-NETLOG_MAX_ENTRIES));
+  }
+}
+
+function netlogGetAll() { return _netBuffer.slice(); }
+
+function netlogClear() {
+  _netBuffer.length = 0;
+  _netPending.clear();
+  _lastHostCookies.clear();
+  chrome.storage.local.set({ [NETLOG_STORAGE_KEY]: [] });
+}
+
+function _netlogFlush(force = false) {
+  _netFlushCounter++;
+  if (!force && _netFlushCounter % NETLOG_FLUSH_EVERY_N !== 0) return;
+  chrome.storage.local.set({ [NETLOG_STORAGE_KEY]: _netBuffer.slice(-NETLOG_MAX_ENTRIES) });
+}
+
+function _netlogPush(entry) {
+  _netBuffer.push(entry);
+  if (_netBuffer.length > NETLOG_MAX_ENTRIES) {
+    _netBuffer.splice(0, _netBuffer.length - NETLOG_MAX_ENTRIES);
+  }
+  _netlogFlush(entry.category === "business_error" ||
+               entry.category === "signature_failure" ||
+               entry.category === "risk_redirect");
+  // 通知 popup 增量
+  chrome.runtime.sendMessage({ type: "NETLOG_ENTRY_ADDED", entry }).catch(() => {});
+}

--- a/extension/netlogger.js
+++ b/extension/netlogger.js
@@ -7,7 +7,7 @@
  */
 
 const NETLOG_MAX_ENTRIES   = 500;
-const NETLOG_REQBODY_MAX   = 2048;
+const NETLOG_REQBODY_MAX   = 8192;
 const NETLOG_RESPBODY_MAX  = 4096;
 const NETLOG_FLUSH_EVERY_N = 10;
 const NETLOG_STORAGE_KEY   = "netLog";

--- a/extension/netlogger.js
+++ b/extension/netlogger.js
@@ -76,8 +76,6 @@ const NETLOG_RESP_HEADER_WHITELIST = new Set([
   "content-type", "server", "x-application-context",
 ]);
 
-const NETLOG_COOKIE_KEYS = ["a1", "web_session", "webId", "gid"];
-
 const NETLOG_SKIP_TYPES = new Set(["image", "font", "stylesheet", "media"]);
 
 function _filterHeaders(rawHeaders, whitelist) {
@@ -251,9 +249,9 @@ chrome.webRequest.onHeadersReceived.addListener(
 // ─── Step 3.5: onCompleted + onErrorOccurred（finalize 入栈） ─────────────────
 
 function _netlogFinalize(details, isError) {
-  if (!_netEnabled) return;
   const entry = _netPending.get(details.requestId);
   _netPending.delete(details.requestId);
+  if (!_netEnabled) return;
   if (!entry) return;
   entry.duration_ms = Date.now() - entry._t0;
   delete entry._t0;
@@ -266,7 +264,14 @@ function _netlogFinalize(details, isError) {
   entry.cookieDiff = _netlogComputeCookieDiff(entry);
   if (entry.cookieDiff) {
     entry.category = entry.category === "other" ? "cookie_change" : entry.category;
-    entry.signals.push("set_cookie_changed:" + entry.cookieDiff.added.join(","));
+    const diffParts = [];
+    if (entry.cookieDiff.added.length) {
+      diffParts.push("added:" + entry.cookieDiff.added.join(","));
+    }
+    if (entry.cookieDiff.removed.length) {
+      diffParts.push("removed:" + entry.cookieDiff.removed.join(","));
+    }
+    entry.signals.push("set_cookie_changed:" + diffParts.join(";"));
   }
 
   _netlogPush(entry);
@@ -292,7 +297,7 @@ function netlogIngestInterceptor(payload) {
   for (let i = _netBuffer.length - 1; i >= 0; i--) {
     const e = _netBuffer[i];
     if (payload.ts - e.ts > NETLOG_INTERCEPTOR_WINDOW_MS) break;
-    if (e.method === payload.method && e.url === payload.url && !e.respBody) {
+    if (e.method === payload.method && _netlogUrlMatch(e.url, payload.url) && !e.respBody) {
       e.respBody = payload.respBody;
       // 合并 interceptor 头（webRequest 拿不到的应用层头）
       for (const [k, v] of Object.entries(payload.reqHeaders || {})) {
@@ -315,7 +320,7 @@ function netlogIngestInterceptor(payload) {
     path: (() => { try { const u = new URL(payload.url); return u.pathname + (u.search || ""); } catch (_) { return payload.url; } })(),
     resourceType: "xmlhttprequest",
     tabId: -1,
-    reqHeaders: payload.reqHeaders || {},
+    reqHeaders: {},
     reqBody: null,
     reqFingerprint: null,
     status: payload.status,
@@ -332,6 +337,13 @@ function netlogIngestInterceptor(payload) {
     errorCode: null,
     _orphan: true,
   };
+  // 过白名单（与 webRequest 路径保持一致）
+  for (const [k, v] of Object.entries(payload.reqHeaders || {})) {
+    const lk = k.toLowerCase();
+    if (NETLOG_REQ_HEADER_WHITELIST.has(lk)) {
+      orphanEntry.reqHeaders[lk] = v;
+    }
+  }
   // orphan 也跑分类
   const { category, signals } = _netlogClassify(orphanEntry);
   orphanEntry.category = category;
@@ -368,7 +380,7 @@ function _netlogClassify(entry) {
     signals.push("fingerprint_upload");
     if (fpBodyHit) signals.push(`body_contains:${fpBodyHit}`);
   } else if (entry.setCookie && entry.setCookie.length > 0) {
-    // cookie_change 由 cookieDiff 进一步判断（见下）
+    // 阻断：带 Set-Cookie 的请求不归 page_nav/business_api，留给 _netlogFinalize 中的 cookieDiff 二阶段升级为 cookie_change
     category = "other";
   } else if (entry.resourceType === "main_frame") {
     category = "page_nav";
@@ -377,6 +389,24 @@ function _netlogClassify(entry) {
   }
 
   return { category, signals };
+}
+
+function _netlogUrlMatch(webRequestUrl, interceptorUrl) {
+  if (webRequestUrl === interceptorUrl) return true;
+  // interceptor 可能拿到相对路径 (fetch("/api/foo")) 或绝对路径
+  // webRequest 总是绝对路径
+  if (interceptorUrl.startsWith("/")) {
+    try {
+      return new URL(webRequestUrl).pathname + new URL(webRequestUrl).search
+             === interceptorUrl.split("#")[0];
+    } catch (_) { return false; }
+  }
+  // 都是绝对路径但有 query 顺序差异
+  try {
+    const a = new URL(webRequestUrl);
+    const b = new URL(interceptorUrl);
+    return a.host === b.host && a.pathname === b.pathname;
+  } catch (_) { return false; }
 }
 
 function _netlogComputeCookieDiff(entry) {

--- a/extension/netlogger.js
+++ b/extension/netlogger.js
@@ -258,7 +258,17 @@ function _netlogFinalize(details, isError) {
   entry.duration_ms = Date.now() - entry._t0;
   delete entry._t0;
   if (isError) entry.err = details.error || "network_error";
-  // 分类逻辑由后续 task 5 接入
+
+  // 分类 + cookieDiff
+  const { category, signals } = _netlogClassify(entry);
+  entry.category = category;
+  entry.signals = signals;
+  entry.cookieDiff = _netlogComputeCookieDiff(entry);
+  if (entry.cookieDiff) {
+    entry.category = entry.category === "other" ? "cookie_change" : entry.category;
+    entry.signals.push("set_cookie_changed:" + entry.cookieDiff.added.join(","));
+  }
+
   _netlogPush(entry);
 }
 
@@ -294,7 +304,7 @@ function netlogIngestInterceptor(payload) {
   }
 
   // 没关联上，独立存
-  _netlogPush({
+  const orphanEntry = {
     id: `${payload.ts}_intercept`,
     requestId: "",
     ts: payload.ts,
@@ -321,5 +331,61 @@ function netlogIngestInterceptor(payload) {
     redirectTo: null,
     errorCode: null,
     _orphan: true,
-  });
+  };
+  // orphan 也跑分类
+  const { category, signals } = _netlogClassify(orphanEntry);
+  orphanEntry.category = category;
+  orphanEntry.signals = signals;
+  _netlogPush(orphanEntry);
+}
+
+// ─── Step 5.1: 分类 + cookieDiff 函数 ────────────────────────────────────────
+
+const NETLOG_FP_HOST_KEYWORDS = ["fp", "sec", "aegis", "sentry", "track", "log"];
+const NETLOG_FP_BODY_KEYWORDS = ["webdriver", "navigator", "screen", "timezone", "platform"];
+
+function _netlogClassify(entry) {
+  const signals = [];
+  let category = "other";
+
+  const hostLow = entry.host.toLowerCase();
+  const isFpHost = NETLOG_FP_HOST_KEYWORDS.some(kw => hostLow.includes(kw));
+  const bodyLow = (entry.reqBody || "").toLowerCase();
+  const fpBodyHit = NETLOG_FP_BODY_KEYWORDS.find(kw => bodyLow.includes(kw));
+
+  // 优先级：signature_failure > risk_redirect > business_error > fingerprint_upload > cookie_change > business_api > page_nav > other
+  if (entry.errorCode && /^30003[123]$/.test(entry.errorCode)) {
+    category = "signature_failure";
+    signals.push(`error_code:${entry.errorCode}`);
+  } else if (entry.redirectTo && /\/(404|login)(\/|\?|$)/.test(entry.redirectTo)) {
+    category = "risk_redirect";
+    signals.push(`redirect:${entry.redirectTo.slice(0, 60)}`);
+  } else if ([401, 403, 461, 999].includes(entry.status)) {
+    category = "business_error";
+    signals.push(`status:${entry.status}`);
+  } else if (isFpHost || fpBodyHit) {
+    category = "fingerprint_upload";
+    signals.push("fingerprint_upload");
+    if (fpBodyHit) signals.push(`body_contains:${fpBodyHit}`);
+  } else if (entry.setCookie && entry.setCookie.length > 0) {
+    // cookie_change 由 cookieDiff 进一步判断（见下）
+    category = "other";
+  } else if (entry.resourceType === "main_frame") {
+    category = "page_nav";
+  } else if (entry.path && entry.path.includes("/api/") && entry.status >= 200 && entry.status < 300) {
+    category = "business_api";
+  }
+
+  return { category, signals };
+}
+
+function _netlogComputeCookieDiff(entry) {
+  if (!entry.setCookie || entry.setCookie.length === 0) return null;
+  const prev = _lastHostCookies.get(entry.host) || new Set();
+  const curr = new Set(entry.setCookie);
+  const added = [...curr].filter(k => !prev.has(k));
+  const removed = [...prev].filter(k => !curr.has(k));
+  _lastHostCookies.set(entry.host, curr);
+  if (added.length === 0 && removed.length === 0) return null;
+  return { added, removed, changed: [] };
 }

--- a/extension/netlogger.js
+++ b/extension/netlogger.js
@@ -270,3 +270,56 @@ chrome.webRequest.onErrorOccurred.addListener(
   (d) => _netlogFinalize(d, true),
   NETLOG_URL_FILTER,
 );
+
+// ─── Step 4.6: ingestInterceptor（关联回填） ─────────────────────────────────
+
+const NETLOG_INTERCEPTOR_WINDOW_MS = 2000;
+
+function netlogIngestInterceptor(payload) {
+  if (!_netEnabled || !payload) return;
+
+  // 在最近 2s 内倒序找匹配 (method + url)，给该 entry 填响应体
+  for (let i = _netBuffer.length - 1; i >= 0; i--) {
+    const e = _netBuffer[i];
+    if (payload.ts - e.ts > NETLOG_INTERCEPTOR_WINDOW_MS) break;
+    if (e.method === payload.method && e.url === payload.url && !e.respBody) {
+      e.respBody = payload.respBody;
+      // 合并 interceptor 头（webRequest 拿不到的应用层头）
+      for (const [k, v] of Object.entries(payload.reqHeaders || {})) {
+        const lk = k.toLowerCase();
+        if (!e.reqHeaders[lk]) e.reqHeaders[lk] = v;
+      }
+      return;
+    }
+  }
+
+  // 没关联上，独立存
+  _netlogPush({
+    id: `${payload.ts}_intercept`,
+    requestId: "",
+    ts: payload.ts,
+    tsLabel: _tsLabel(payload.ts),
+    method: payload.method,
+    url: payload.url,
+    host: (() => { try { return new URL(payload.url).host; } catch (_) { return ""; } })(),
+    path: (() => { try { const u = new URL(payload.url); return u.pathname + (u.search || ""); } catch (_) { return payload.url; } })(),
+    resourceType: "xmlhttprequest",
+    tabId: -1,
+    reqHeaders: payload.reqHeaders || {},
+    reqBody: null,
+    reqFingerprint: null,
+    status: payload.status,
+    statusLine: "",
+    respHeaders: {},
+    respBody: payload.respBody,
+    setCookie: null,
+    duration_ms: 0,
+    err: null,
+    category: "other",
+    signals: [],
+    cookieDiff: null,
+    redirectTo: null,
+    errorCode: null,
+    _orphan: true,
+  });
+}

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html lang="zh">
+<head>
+  <meta charset="UTF-8">
+  <style>
+    body {
+      width: 220px;
+      padding: 16px;
+      font-family: -apple-system, "PingFang SC", "Microsoft YaHei", sans-serif;
+      font-size: 13px;
+      color: #333;
+      margin: 0;
+    }
+    h3 {
+      margin: 0 0 12px;
+      font-size: 14px;
+      color: #111;
+    }
+    .row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 8px;
+    }
+    .label { color: #666; }
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 5px;
+      padding: 2px 8px;
+      border-radius: 10px;
+      font-size: 12px;
+      font-weight: 500;
+    }
+    .badge.ok  { background: #e6f4ea; color: #1e8e3e; }
+    .badge.err { background: #fce8e6; color: #c5221f; }
+    .badge.loading { background: #f1f3f4; color: #888; }
+    .dot {
+      width: 7px; height: 7px;
+      border-radius: 50%;
+    }
+    .dot.ok  { background: #1e8e3e; }
+    .dot.err { background: #c5221f; }
+    .dot.loading { background: #aaa; }
+    .divider { border: none; border-top: 1px solid #eee; margin: 10px 0; }
+    .hint { color: #999; font-size: 11px; line-height: 1.5; }
+    .btn {
+      width: 100%;
+      padding: 6px 0;
+      border: none;
+      border-radius: 6px;
+      font-size: 12px;
+      font-weight: 500;
+      cursor: pointer;
+      background: #1a73e8;
+      color: #fff;
+      margin-top: 4px;
+    }
+    .btn:disabled { background: #aaa; cursor: default; }
+    .risk-result { margin-top: 8px; font-size: 11px; line-height: 1.6; }
+    .risk-badge {
+      display: inline-block;
+      padding: 1px 8px;
+      border-radius: 8px;
+      font-weight: 600;
+      font-size: 12px;
+    }
+    .risk-safe   { background: #e6f4ea; color: #1e8e3e; }
+    .risk-low    { background: #fef9e7; color: #b7950b; }
+    .risk-medium { background: #fce8e6; color: #c5221f; }
+    .risk-high   { background: #f4c6c6; color: #a50000; }
+    .issue-list  { margin: 4px 0 0; padding: 0; list-style: none; }
+    .issue-list li { padding: 1px 0; color: #555; }
+  </style>
+</head>
+<body>
+  <h3>XHS Bridge</h3>
+
+  <div class="row">
+    <span class="label">Bridge 服务</span>
+    <span class="badge loading" id="bridge-status">
+      <span class="dot loading" id="bridge-dot"></span>
+      <span id="bridge-text">检测中...</span>
+    </span>
+  </div>
+
+  <div class="row">
+    <span class="label">扩展连接</span>
+    <span class="badge loading" id="ext-status">
+      <span class="dot loading" id="ext-dot"></span>
+      <span id="ext-text">检测中...</span>
+    </span>
+  </div>
+
+  <hr class="divider">
+  <p class="hint" id="hint">正在连接 bridge server...</p>
+
+  <hr class="divider">
+  <button class="btn" id="scan-btn">扫描风控</button>
+  <div class="risk-result" id="risk-result" style="display:none">
+    <div>风险等级：<span class="risk-badge" id="risk-level-badge">-</span></div>
+    <ul class="issue-list" id="issue-list"></ul>
+  </div>
+
+  <hr class="divider">
+  <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:6px">
+    <span style="font-size:12px;font-weight:600;color:#333">404 诊断</span>
+    <span class="badge loading" id="intercept-badge" style="font-size:10px;padding:1px 6px">
+      <span class="dot loading" id="intercept-dot"></span>
+      <span id="intercept-count">监听中</span>
+    </span>
+  </div>
+  <div id="event-list" style="font-size:10px;line-height:1.6;max-height:160px;overflow-y:auto"></div>
+  <button class="btn" id="clear-btn" style="background:#888;margin-top:4px;font-size:11px;padding:4px 0">清空记录</button>
+
+  <script type="module" src="popup.js"></script>
+</body>
+</html>

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -10,7 +10,9 @@
       font-size: 13px;
       color: #333;
       margin: 0;
+      transition: width 0.2s;
     }
+    body.netlog-on { width: 580px; }
     h3 {
       margin: 0 0 12px;
       font-size: 14px;
@@ -71,10 +73,63 @@
     .risk-high   { background: #f4c6c6; color: #a50000; }
     .issue-list  { margin: 4px 0 0; padding: 0; list-style: none; }
     .issue-list li { padding: 1px 0; color: #555; }
+    .netlog-card { display: none; }
+    body.netlog-on .netlog-card { display: block; }
+    .netlog-tabs { display: flex; gap: 4px; margin-bottom: 6px; }
+    .netlog-tab {
+      padding: 3px 10px;
+      font-size: 11px;
+      cursor: pointer;
+      border-radius: 4px;
+      background: #f1f3f4;
+      color: #555;
+    }
+    .netlog-tab.active { background: #1a73e8; color: #fff; }
+    .netlog-row {
+      font-family: ui-monospace, "SF Mono", Menlo, monospace;
+      font-size: 10px;
+      line-height: 1.5;
+      padding: 2px 4px;
+      border-radius: 3px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      cursor: pointer;
+    }
+    .netlog-row:hover { background: #f8f9fa; }
+    .netlog-row.cat-fingerprint_upload { color: #b7950b; }
+    .netlog-row.cat-business_error,
+    .netlog-row.cat-risk_redirect,
+    .netlog-row.cat-signature_failure { color: #c5221f; }
+    .netlog-row.cat-cookie_change { color: #1565c0; }
+    .netlog-list { max-height: 320px; overflow-y: auto; border: 1px solid #eee; padding: 4px; border-radius: 4px; }
+    .netlog-detail {
+      background: #fafafa;
+      border: 1px solid #eee;
+      border-radius: 4px;
+      padding: 6px;
+      margin-top: 6px;
+      font-family: ui-monospace, monospace;
+      font-size: 10px;
+      max-height: 200px;
+      overflow-y: auto;
+      white-space: pre-wrap;
+      word-break: break-all;
+    }
+    .netlog-toolbar { display: flex; gap: 6px; margin-bottom: 6px; }
+    .netlog-toolbar button {
+      flex: 1;
+      padding: 3px 0;
+      font-size: 11px;
+      border: 1px solid #ddd;
+      border-radius: 4px;
+      background: #fff;
+      cursor: pointer;
+    }
   </style>
 </head>
 <body>
-  <h3>XHS Bridge</h3>
+  <h3 id="title-hit" style="cursor:default;user-select:none">XHS Bridge</h3>
 
   <div class="row">
     <span class="label">Bridge 服务</span>
@@ -112,6 +167,25 @@
   </div>
   <div id="event-list" style="font-size:10px;line-height:1.6;max-height:160px;overflow-y:auto"></div>
   <button class="btn" id="clear-btn" style="background:#888;margin-top:4px;font-size:11px;padding:4px 0">清空记录</button>
+
+  <hr class="divider">
+  <div class="netlog-card">
+    <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:6px">
+      <span style="font-size:12px;font-weight:600;color:#333">NetLog</span>
+      <span style="font-size:10px;color:#888" id="netlog-count">0 条</span>
+    </div>
+    <div class="netlog-tabs">
+      <div class="netlog-tab active" data-tab="stream">时序流</div>
+      <div class="netlog-tab" data-tab="category">检测维度</div>
+    </div>
+    <div class="netlog-toolbar">
+      <button id="netlog-clear">清空</button>
+      <button id="netlog-export">导出 JSON</button>
+      <button id="netlog-disable">关闭</button>
+    </div>
+    <div class="netlog-list" id="netlog-list"></div>
+    <div class="netlog-detail" id="netlog-detail" style="display:none"></div>
+  </div>
 
   <script type="module" src="popup.js"></script>
 </body>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -172,6 +172,9 @@ titleEl?.addEventListener("click", () => {
   _netlogHitTimer = setTimeout(() => { _netlogHits = 0; }, NETLOG_HIT_RESET_MS);
   if (_netlogHits >= NETLOG_HIT_TARGET) {
     _netlogHits = 0;
+    titleEl.style.transition = "background 0.2s";
+    titleEl.style.background = "#fef9e7";
+    setTimeout(() => { titleEl.style.background = ""; }, 300);
     chrome.runtime.sendMessage({ type: "NETLOG_GET_ENABLED" }, (resp) => {
       if (resp?.enabled) {
         if (confirm("关闭 NetLog?")) toggleNetlog(false);
@@ -272,6 +275,8 @@ function showNetlogDetail(entry) {
   if (!el) return;
   el.style.display = "block";
   el.textContent = JSON.stringify(entry, null, 2);
+  el.onclick = () => { el.style.display = "none"; };
+  el.title = "点击此处关闭详情";
 }
 
 function renderNetlogCategory(container) {
@@ -295,9 +300,11 @@ function renderNetlogCategory(container) {
         ${items.map((e, i) => {
           const path = e.path.length > 60 ? e.path.slice(0, 57) + "…" : e.path;
           const signal = (e.signals || []).slice(0, 2).join(", ");
-          return `<div class="netlog-row cat-${e.category}" data-cat="${cat}" data-idx="${i}">
-            ${e.tsLabel}  ${e.method.padEnd(4)} ${e.status || "?"}  ${e.host.replace(/^www\./, "")}${path}${signal ? "  ["+signal+"]" : ""}
-          </div>`;
+          const signalSuffix = signal ? "  [" + signal + "]" : "";
+          const hostShort = e.host.replace(/^www\./, "");
+          return `<div class="netlog-row cat-${e.category}" data-cat="${cat}" data-idx="${i}">` +
+                 `${e.tsLabel}  ${e.method.padEnd(4)} ${e.status || "?"}  ` +
+                 `${hostShort}${path}${signalSuffix}</div>`;
         }).join("")}
       </details>
     `);

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,0 +1,159 @@
+function renderStatus(wsConnected) {
+  set("bridge-status", "bridge-dot", "bridge-text", wsConnected, wsConnected ? "已连接" : "未连接");
+  set("ext-status",   "ext-dot",   "ext-text",   true, "运行中");
+  document.getElementById("hint").textContent = wsConnected
+    ? "一切正常，可以运行 Python 脚本。"
+    : "请先运行：python scripts/cli.py <命令>";
+}
+
+function set(badgeId, dotId, textId, ok, label) {
+  const cls = ok ? "ok" : "err";
+  document.getElementById(badgeId).className  = `badge ${cls}`;
+  document.getElementById(dotId).className    = `dot ${cls}`;
+  document.getElementById(textId).textContent = label;
+}
+
+// 初始化：拉取当前状态
+try {
+  chrome.runtime.sendMessage({ type: "GET_STATUS" }, (resp) => {
+    if (chrome.runtime.lastError || !resp?.success) {
+      renderStatus(false);
+      return;
+    }
+    renderStatus(resp.status.wsConnected);
+  });
+} catch (e) {
+  renderStatus(false);
+}
+
+// 实时监听状态变化（background 主动推送）
+chrome.runtime.onMessage.addListener((msg) => {
+  if (msg.type === "STATUS_CHANGED") {
+    renderStatus(msg.status.wsConnected);
+  }
+});
+
+// ── 风控扫描 ──────────────────────────────────────────────────
+
+const RISK_LABELS = { safe: "安全", low: "低风险", medium: "中风险", high: "高风险" };
+
+document.getElementById("scan-btn").addEventListener("click", async () => {
+  const btn = document.getElementById("scan-btn");
+  const resultEl = document.getElementById("risk-result");
+  btn.disabled = true;
+  btn.textContent = "扫描中...";
+  resultEl.style.display = "none";
+
+  try {
+    const report = await chrome.runtime.sendMessage({ type: "ANALYZE_RISK_CONTROL" });
+    if (!report || report.error) {
+      showRiskError(report?.error || "扫描失败，请检查扩展连接状态");
+      return;
+    }
+    renderRiskReport(report);
+  } catch (e) {
+    showRiskError(String(e.message || e));
+  } finally {
+    btn.disabled = false;
+    btn.textContent = "重新扫描";
+  }
+});
+
+function renderRiskReport(report) {
+  const badge = document.getElementById("risk-level-badge");
+  const level = report.risk_level || "safe";
+  badge.textContent = RISK_LABELS[level] || level;
+  badge.className = `risk-badge risk-${level}`;
+
+  const list = document.getElementById("issue-list");
+  list.innerHTML = "";
+  if (!report.issues || report.issues.length === 0) {
+    const li = document.createElement("li");
+    li.textContent = "✓ 未发现风控特征";
+    li.style.color = "#1e8e3e";
+    list.appendChild(li);
+  } else {
+    for (const issue of report.issues) {
+      const li = document.createElement("li");
+      const icon = issue.level === "high" ? "✗" : issue.level === "medium" ? "!" : "·";
+      li.textContent = `${icon} ${issue.msg}`;
+      li.style.color = issue.level === "high" ? "#c5221f" : issue.level === "medium" ? "#b7950b" : "#666";
+      list.appendChild(li);
+    }
+  }
+
+  document.getElementById("risk-result").style.display = "block";
+}
+
+function showRiskError(msg) {
+  const badge = document.getElementById("risk-level-badge");
+  badge.textContent = "错误";
+  badge.className = "risk-badge risk-medium";
+  const list = document.getElementById("issue-list");
+  list.innerHTML = `<li style="color:#c5221f">${msg}</li>`;
+  document.getElementById("risk-result").style.display = "block";
+}
+
+// ── 404 诊断事件面板 ──────────────────────────────────────────
+
+const CAUSE_COLORS = {
+  token:             "#b7950b",
+  signature:         "#1565c0",
+  session:           "#6a1b9a",
+  ip_block:          "#c5221f",
+  account_block:     "#a50000",
+  risk_control:      "#c5221f",
+  content_unavailable: "#555",
+};
+
+function renderEvents(events) {
+  const el = document.getElementById("event-list");
+  const badge  = document.getElementById("intercept-badge");
+  const dot    = document.getElementById("intercept-dot");
+  const count  = document.getElementById("intercept-count");
+
+  if (events.length === 0) {
+    el.innerHTML = '<span style="color:#aaa">暂无拦截记录</span>';
+    badge.className = "badge loading";
+    dot.className   = "dot loading";
+    count.textContent = "监听中";
+    return;
+  }
+
+  badge.className = "badge err";
+  dot.className   = "dot err";
+  count.textContent = `${events.length} 条`;
+
+  el.innerHTML = events.slice(0, 10).map(ev => {
+    const color = CAUSE_COLORS[ev.diagnosis?.cause_category] || "#555";
+    const time  = ev.timestamp ? new Date(ev.timestamp).toLocaleTimeString("zh-CN") : "";
+    const urlShort = ev.url.replace(/https?:\/\/[^/]+/, "").slice(0, 45);
+    return `
+      <div style="border-left:3px solid ${color};padding:3px 6px;margin-bottom:4px;background:#fafafa;border-radius:0 4px 4px 0">
+        <div style="color:${color};font-weight:600">[${ev.status}] ${ev.diagnosis?.root_cause || "未知"}</div>
+        <div style="color:#666;font-size:9.5px">${urlShort}</div>
+        <div style="color:#999;font-size:9px">${time} · ${ev.intercept_type || "fetch"}</div>
+      </div>`;
+  }).join("");
+}
+
+// 初始加载历史事件
+chrome.runtime.sendMessage({ type: "GET_404_DIAGNOSTICS" }, (resp) => {
+  renderEvents(resp?.events || []);
+});
+
+// 实时监听新事件
+chrome.runtime.onMessage.addListener((msg) => {
+  if (msg.type === "BLOCK_EVENT_ADDED") {
+    chrome.runtime.sendMessage({ type: "GET_404_DIAGNOSTICS" }, (resp) => {
+      renderEvents(resp?.events || []);
+    });
+  }
+});
+
+// 清空按钮
+document.getElementById("clear-btn").addEventListener("click", () => {
+  chrome.runtime.sendMessage({ type: "XHS_BLOCK_EVENT", event: null }).catch(() => {});
+  // 直接通过 background command 清空
+  chrome.storage.session.set({ blockEvents: [] }, () => renderEvents([]));
+});

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -274,6 +274,48 @@ function showNetlogDetail(entry) {
   el.textContent = JSON.stringify(entry, null, 2);
 }
 
+function renderNetlogCategory(container) {
+  const groups = {};
+  for (const e of _netlogEntries) {
+    if (!groups[e.category]) groups[e.category] = [];
+    groups[e.category].push(e);
+  }
+
+  const order = ["fingerprint_upload", "signature_failure", "risk_redirect",
+                 "business_error", "cookie_change", "business_api", "page_nav", "other"];
+
+  const sections = [];
+  for (const cat of order) {
+    if (!groups[cat] || groups[cat].length === 0) continue;
+    const label = NETLOG_CAT_LABEL[cat];
+    const items = groups[cat].slice(-50);  // 每类最多展示 50 条
+    sections.push(`
+      <details open style="margin-bottom:6px">
+        <summary style="cursor:pointer;font-size:11px;font-weight:600;color:#444">▾ ${label} (${groups[cat].length})</summary>
+        ${items.map((e, i) => {
+          const path = e.path.length > 60 ? e.path.slice(0, 57) + "…" : e.path;
+          const signal = (e.signals || []).slice(0, 2).join(", ");
+          return `<div class="netlog-row cat-${e.category}" data-cat="${cat}" data-idx="${i}">
+            ${e.tsLabel}  ${e.method.padEnd(4)} ${e.status || "?"}  ${e.host.replace(/^www\./, "")}${path}${signal ? "  ["+signal+"]" : ""}
+          </div>`;
+        }).join("")}
+      </details>
+    `);
+  }
+
+  container.innerHTML = sections.join("") || '<div style="color:#aaa;font-size:11px;padding:8px">暂无数据</div>';
+
+  // 详情点击：data-cat + data-idx 反查
+  container.querySelectorAll(".netlog-row").forEach(row => {
+    row.addEventListener("click", () => {
+      const cat = row.dataset.cat;
+      const idx = Number(row.dataset.idx);
+      const entry = groups[cat]?.slice(-50)[idx];
+      if (entry) showNetlogDetail(entry);
+    });
+  });
+}
+
 // tab 切换
 document.querySelectorAll(".netlog-tab").forEach(tab => {
   tab.addEventListener("click", () => {
@@ -291,4 +333,16 @@ chrome.runtime.onMessage.addListener((msg) => {
     if (_netlogEntries.length > 500) _netlogEntries.splice(0, _netlogEntries.length - 500);
     renderNetlog();
   }
+});
+
+document.getElementById("netlog-export")?.addEventListener("click", () => {
+  const blob = new Blob([JSON.stringify(_netlogEntries, null, 2)], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `xhs-netlog-${new Date().toISOString().replace(/[:.]/g, "-")}.json`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
 });

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -157,3 +157,138 @@ document.getElementById("clear-btn").addEventListener("click", () => {
   // 直接通过 background command 清空
   chrome.storage.session.set({ blockEvents: [] }, () => renderEvents([]));
 });
+
+// ─── NetLog 彩蛋激活 + 状态 ──────────────────────────────────────
+
+const NETLOG_HIT_TARGET = 5;
+const NETLOG_HIT_RESET_MS = 500;
+let _netlogHits = 0;
+let _netlogHitTimer = null;
+
+const titleEl = document.getElementById("title-hit");
+titleEl?.addEventListener("click", () => {
+  _netlogHits++;
+  clearTimeout(_netlogHitTimer);
+  _netlogHitTimer = setTimeout(() => { _netlogHits = 0; }, NETLOG_HIT_RESET_MS);
+  if (_netlogHits >= NETLOG_HIT_TARGET) {
+    _netlogHits = 0;
+    chrome.runtime.sendMessage({ type: "NETLOG_GET_ENABLED" }, (resp) => {
+      if (resp?.enabled) {
+        if (confirm("关闭 NetLog?")) toggleNetlog(false);
+      } else {
+        toggleNetlog(true);
+      }
+    });
+  }
+});
+
+function toggleNetlog(enabled) {
+  chrome.runtime.sendMessage({ type: "NETLOG_SET_ENABLED", enabled }, () => {
+    applyNetlogUI(enabled);
+    if (enabled) refreshNetlog();
+  });
+}
+
+function applyNetlogUI(enabled) {
+  document.body.classList.toggle("netlog-on", !!enabled);
+}
+
+// 初始化：根据当前启用状态决定显示
+chrome.runtime.sendMessage({ type: "NETLOG_GET_ENABLED" }, (resp) => {
+  if (resp?.enabled) {
+    applyNetlogUI(true);
+    refreshNetlog();
+  }
+});
+
+document.getElementById("netlog-disable")?.addEventListener("click", () => toggleNetlog(false));
+document.getElementById("netlog-clear")?.addEventListener("click", () => {
+  chrome.runtime.sendMessage({ type: "NETLOG_CLEAR" }, () => refreshNetlog());
+});
+
+// ─── NetLog 时序流渲染 ──────────────────────────────────────────
+
+let _netlogEntries = [];
+let _netlogTab = "stream";
+
+function refreshNetlog() {
+  chrome.runtime.sendMessage({ type: "NETLOG_GET_ALL" }, (resp) => {
+    _netlogEntries = resp?.entries || [];
+    renderNetlog();
+  });
+}
+
+function renderNetlog() {
+  const countEl = document.getElementById("netlog-count");
+  if (countEl) countEl.textContent = `${_netlogEntries.length} 条`;
+
+  const list = document.getElementById("netlog-list");
+  if (!list) return;
+
+  if (_netlogTab === "stream") {
+    renderNetlogStream(list);
+  } else {
+    renderNetlogCategory(list);
+  }
+}
+
+const NETLOG_CAT_LABEL = {
+  fingerprint_upload: "指纹↑",
+  business_error: "错误",
+  risk_redirect: "风控跳",
+  signature_failure: "签名失败",
+  cookie_change: "Cookie 变",
+  business_api: "API",
+  page_nav: "导航",
+  other: "其他",
+};
+
+function renderNetlogStream(container) {
+  // 最新在底，倒序展示前 200 条
+  const slice = _netlogEntries.slice(-200);
+  container.innerHTML = slice.map((e, i) => {
+    const star = (e.category === "fingerprint_upload" || e.category === "risk_redirect" ||
+                  e.category === "signature_failure") ? " ★" : "";
+    const path = e.path.length > 50 ? e.path.slice(0, 47) + "…" : e.path;
+    const host = e.host.replace(/^www\./, "");
+    return `<div class="netlog-row cat-${e.category}" data-idx="${i}">
+      ${e.tsLabel}  ${e.method.padEnd(4)} ${e.status || "?"}  ${e.duration_ms}ms  ${host}${path}  [${NETLOG_CAT_LABEL[e.category]}]${star}
+    </div>`;
+  }).join("");
+
+  // 点击展开详情
+  container.querySelectorAll(".netlog-row").forEach(row => {
+    row.addEventListener("click", () => {
+      const idx = Number(row.dataset.idx);
+      showNetlogDetail(slice[idx]);
+    });
+  });
+  // 滚到底
+  container.scrollTop = container.scrollHeight;
+}
+
+function showNetlogDetail(entry) {
+  const el = document.getElementById("netlog-detail");
+  if (!el) return;
+  el.style.display = "block";
+  el.textContent = JSON.stringify(entry, null, 2);
+}
+
+// tab 切换
+document.querySelectorAll(".netlog-tab").forEach(tab => {
+  tab.addEventListener("click", () => {
+    document.querySelectorAll(".netlog-tab").forEach(t => t.classList.remove("active"));
+    tab.classList.add("active");
+    _netlogTab = tab.dataset.tab;
+    renderNetlog();
+  });
+});
+
+// 实时增量
+chrome.runtime.onMessage.addListener((msg) => {
+  if (msg.type === "NETLOG_ENTRY_ADDED" && document.body.classList.contains("netlog-on")) {
+    _netlogEntries.push(msg.entry);
+    if (_netlogEntries.length > 500) _netlogEntries.splice(0, _netlogEntries.length - 500);
+    renderNetlog();
+  }
+});

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -82,7 +82,7 @@ def _ensure_bridge_ready(bridge_url: str) -> None:
         scripts_dir = Path(__file__).parent
         kwargs: dict = {}
         if sys.platform == "win32":
-            kwargs["creationflags"] = subprocess.CREATE_NEW_CONSOLE
+            kwargs["creationflags"] = subprocess.CREATE_NO_WINDOW
         subprocess.Popen(
             [sys.executable, str(scripts_dir / "bridge_server.py")],
             **kwargs,
@@ -418,8 +418,28 @@ def cmd_get_feed_detail(args: argparse.Namespace) -> None:
             args.xsec_token,
             load_all_comments=args.load_all_comments,
             config=config,
+            keyword=getattr(args, "keyword", "篮球"),
         )
         _output(detail.to_dict())
+    except Exception as e:
+        # 附带 404 诊断事件，帮助定位根因
+        diagnostics: list = []
+        try:
+            diagnostics = page.get_404_diagnostics() or []
+        except Exception:
+            pass
+        err_data: dict = {"success": False, "error": str(e)}
+        if diagnostics:
+            latest = diagnostics[-1]
+            err_data["diagnosis"] = {
+                "root_cause": latest.get("diagnosis", {}).get("root_cause"),
+                "cause_category": latest.get("diagnosis", {}).get("cause_category"),
+                "detail": latest.get("diagnosis", {}).get("detail"),
+                "how_xhs_decides": latest.get("diagnosis", {}).get("how_xhs_decides"),
+                "url": latest.get("url"),
+                "final_url": latest.get("final_url"),
+            }
+        _output(err_data, exit_code=2)
     finally:
         browser.close()
 
@@ -669,6 +689,73 @@ def cmd_next_step(args: argparse.Namespace) -> None:
         browser.close()
 
 
+def cmd_diagnose_404(args: argparse.Namespace) -> None:
+    """获取拦截器捕获的 404 诊断事件，打印根因分析报告。"""
+    browser, page = _connect(args)
+    try:
+        if args.clear:
+            page.clear_404_diagnostics()
+            _output({"success": True, "message": "诊断记录已清空"})
+            return
+
+        events = page.get_404_diagnostics()
+        if not events:
+            _output({"success": True, "events": [], "message": "暂无拦截记录，请在小红书页面进行操作后重试"})
+            return
+
+        # 控制台可读报告（写到 stderr）
+        logger.info("═" * 60)
+        logger.info("404 诊断报告 — 共 %d 条拦截记录", len(events))
+        logger.info("═" * 60)
+        for i, ev in enumerate(events, 1):
+            diag = ev.get("diagnosis", {})
+            logger.info(
+                "[%d] %s %s → HTTP %s",
+                i, ev.get("method", "?"), ev.get("url", "?")[:80], ev.get("status", "?"),
+            )
+            logger.info("    根因: %s", diag.get("root_cause", "未知"))
+            logger.info("    详情: %s", diag.get("detail", "")[:120])
+            logger.info("    置信: %s | 类别: %s", diag.get("confidence", "?"), diag.get("cause_category", "?"))
+            logger.info("    时间: %s | 页面: %s", ev.get("timestamp", "?"), ev.get("pageUrl", "?")[:60])
+            cookies = ev.get("cookies", {})
+            req = ev.get("request", {})
+            logger.info(
+                "    凭证: web_session=%s a1=%s xs=%s xsec_token=%s",
+                cookies.get("has_web_session"), cookies.get("has_a1"),
+                req.get("has_xs"), bool(req.get("xsec_token")),
+            )
+            logger.info("─" * 60)
+
+        _output({"success": True, "events": events})
+    finally:
+        browser.close()
+
+
+def cmd_check_risk(args: argparse.Namespace) -> None:
+    """分析小红书风控状态：检测自动化特征与 API 拦截情况。"""
+    import json as _json
+
+    browser, page = _connect(args)
+    try:
+        probe_urls = args.probe_urls or []
+        report = page.analyze_risk_control(probe_urls=probe_urls)
+        if not report:
+            _output({"success": False, "error": "扫描返回空结果"}, exit_code=2)
+            return
+
+        risk_level = report.get("risk_level", "unknown")
+        issues = report.get("issues", [])
+
+        # 控制台可读摘要（写到 stderr，不影响 JSON stdout）
+        logger.info("风控扫描完成 | 等级: %s | 问题数: %d", risk_level.upper(), len(issues))
+        for issue in issues:
+            logger.info("  [%s] %s", issue.get("level", "?").upper(), issue.get("msg", ""))
+
+        _output({"success": True, "report": report})
+    finally:
+        browser.close()
+
+
 def cmd_publish_video(args: argparse.Namespace) -> None:
     """发布视频内容。"""
     from xhs.publish_video import publish_video_content
@@ -773,6 +860,7 @@ def build_parser() -> argparse.ArgumentParser:
     sub.add_argument("--max-replies-threshold", type=int, default=10)
     sub.add_argument("--max-comment-items", type=int, default=0)
     sub.add_argument("--scroll-speed", default="normal", help="slow|normal|fast")
+    sub.add_argument("--keyword", default="篮球", help="风控重试时的搜索关键词")
     sub.set_defaults(func=cmd_get_feed_detail)
 
     # user-profile
@@ -877,6 +965,22 @@ def build_parser() -> argparse.ArgumentParser:
     sub = subparsers.add_parser("next-step", help="点击下一步 + 填写描述")
     sub.add_argument("--content-file", required=True)
     sub.set_defaults(func=cmd_next_step)
+
+    # diagnose-404
+    sub = subparsers.add_parser("diagnose-404", help="获取拦截器捕获的 404 根因诊断报告")
+    sub.add_argument("--clear", action="store_true", help="清空已有诊断记录")
+    sub.set_defaults(func=cmd_diagnose_404)
+
+    # check-risk
+    sub = subparsers.add_parser("check-risk", help="分析小红书风控状态（自动化指纹 + API 探测）")
+    sub.add_argument(
+        "--probe-urls",
+        nargs="*",
+        dest="probe_urls",
+        default=[],
+        help="额外探测的 API URL 列表",
+    )
+    sub.set_defaults(func=cmd_check_risk)
 
     return parser
 

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -763,7 +763,7 @@ def cmd_get_netlog(args: argparse.Namespace) -> None:
         if not page.get_netlog_enabled():
             print(json.dumps({
                 "error": "netlogger 未启用",
-                "hint": "请打开扩展 popup，标题"XHS Bridge"连点 5 次激活 NetLog 后重试",
+                "hint": "请打开扩展 popup，标题 XHS Bridge 连点 5 次激活 NetLog 后重试",
             }, ensure_ascii=False, indent=2))
             sys.exit(2)
 
@@ -787,7 +787,7 @@ def cmd_risk_report(args: argparse.Namespace) -> None:
         if not page.get_netlog_enabled():
             print(json.dumps({
                 "error": "netlogger 未启用",
-                "hint": "请打开扩展 popup，标题"XHS Bridge"连点 5 次激活 NetLog 后重试",
+                "hint": "请打开扩展 popup，标题 XHS Bridge 连点 5 次激活 NetLog 后重试",
             }, ensure_ascii=False, indent=2))
             sys.exit(2)
 

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -756,6 +756,48 @@ def cmd_check_risk(args: argparse.Namespace) -> None:
         browser.close()
 
 
+def cmd_get_netlog(args: argparse.Namespace) -> None:
+    """获取 NetLog 原始 entries（最多 500 条）。"""
+    browser, page = _connect(args)
+    try:
+        if not page.get_netlog_enabled():
+            print(json.dumps({
+                "error": "netlogger 未启用",
+                "hint": "请打开扩展 popup，标题"XHS Bridge"连点 5 次激活 NetLog 后重试",
+            }, ensure_ascii=False, indent=2))
+            sys.exit(2)
+
+        entries = page.get_netlog()
+        if args.limit:
+            entries = entries[-args.limit:]
+        print(json.dumps({
+            "total": len(entries),
+            "entries": entries,
+        }, ensure_ascii=False, indent=2))
+    finally:
+        browser.close()
+
+
+def cmd_risk_report(args: argparse.Namespace) -> None:
+    """基于 NetLog 数据生成风控分析报告。"""
+    from xhs.risk_analyzer import analyze
+
+    browser, page = _connect(args)
+    try:
+        if not page.get_netlog_enabled():
+            print(json.dumps({
+                "error": "netlogger 未启用",
+                "hint": "请打开扩展 popup，标题"XHS Bridge"连点 5 次激活 NetLog 后重试",
+            }, ensure_ascii=False, indent=2))
+            sys.exit(2)
+
+        entries = page.get_netlog()
+        report = analyze(entries)
+        print(json.dumps(report, ensure_ascii=False, indent=2))
+    finally:
+        browser.close()
+
+
 def cmd_publish_video(args: argparse.Namespace) -> None:
     """发布视频内容。"""
     from xhs.publish_video import publish_video_content
@@ -981,6 +1023,15 @@ def build_parser() -> argparse.ArgumentParser:
         help="额外探测的 API URL 列表",
     )
     sub.set_defaults(func=cmd_check_risk)
+
+    # get-netlog
+    sub = subparsers.add_parser("get-netlog", help="获取 NetLog 原始 entries（需先在 popup 激活）")
+    sub.add_argument("--limit", type=int, default=None, help="只取最近 N 条")
+    sub.set_defaults(func=cmd_get_netlog)
+
+    # risk-report
+    sub = subparsers.add_parser("risk-report", help="基于 NetLog 生成风控分析报告")
+    sub.set_defaults(func=cmd_risk_report)
 
     return parser
 

--- a/scripts/xhs/bridge.py
+++ b/scripts/xhs/bridge.py
@@ -249,6 +249,18 @@ class BridgePage:
         """
         return self._call("analyze_risk_control", {"probeUrls": probe_urls or []})
 
+    # ─── NetLog 风控数据 ─────────────────────────────────────────
+
+    def get_netlog_enabled(self) -> bool:
+        """检查 NetLog 是否已启用（用户在扩展 popup 上彩蛋激活）。"""
+        result = self._call("get_netlog_enabled") or {}
+        return bool(result.get("enabled"))
+
+    def get_netlog(self) -> list[dict]:
+        """获取当前会话的全部 NetLog entries（最多 500 条环形缓冲）。"""
+        result = self._call("get_netlog") or {}
+        return result.get("entries") or []
+
     # ─── 无操作（原 CDP 专有功能，扩展模式不需要） ─────────────────
 
     def inject_stealth(self) -> None:

--- a/scripts/xhs/bridge.py
+++ b/scripts/xhs/bridge.py
@@ -141,6 +141,9 @@ class BridgePage:
             """
         )
 
+    def click_element_by_text(self, selector: str, text: str) -> None:
+        self._call("click_element_by_text", {"selector": selector, "text": text})
+
     def input_text(self, selector: str, text: str) -> None:
         self._call("input_text", {"selector": selector, "text": text})
 
@@ -225,6 +228,26 @@ class BridgePage:
         if result and result.get("data"):
             return base64.b64decode(result["data"])
         return b""
+
+    # ─── 风控分析 ────────────────────────────────────────────────
+
+    def get_404_diagnostics(self) -> list[dict]:
+        """获取拦截器捕获的 404/461/403/999 诊断事件列表（最近 50 条）。
+        每条事件包含请求上下文、cookie 快照、以及根因分析。
+        """
+        return self._call("get_404_diagnostics") or []
+
+    def clear_404_diagnostics(self) -> None:
+        """清空已存储的诊断事件。"""
+        self._call("clear_404_diagnostics")
+
+    def analyze_risk_control(self, probe_urls: list[str] | None = None) -> dict:
+        """分析小红书风控状态。
+        检查自动化指纹（webdriver、plugins、WebGL 等）、页面风控元素、
+        并实时探测关键 API 端点的响应状态。
+        返回结构化报告，含 risk_level（safe/low/medium/high）和 issues 列表。
+        """
+        return self._call("analyze_risk_control", {"probeUrls": probe_urls or []})
 
     # ─── 无操作（原 CDP 专有功能，扩展模式不需要） ─────────────────
 

--- a/scripts/xhs/cdp.py
+++ b/scripts/xhs/cdp.py
@@ -371,6 +371,61 @@ class Page:
             """
         )
 
+    def simulate_reading_mouse(self, duration_ms: int = 3000) -> None:
+        """模拟阅读鼠标轨迹：逐行扫视 + 随机停顿，通过合成 mousemove 事件实现。
+
+        在页面执行 JS 生成轨迹，Python 侧控制帧间延迟使时序真实。
+        """
+        import math as _math
+
+        # 获取视口尺寸
+        vw = int(self.evaluate("window.innerWidth || 1280") or 1280)
+        vh = int(self.evaluate("window.innerHeight || 800") or 800)
+
+        left   = int(vw * 0.25)
+        right  = int(vw * 0.75)
+        top    = int(vh * 0.20)
+        bottom = int(vh * 0.80)
+
+        def rand(a: int, b: int) -> int:
+            return random.randint(a, b)
+
+        def ease(t: float) -> float:
+            return 2 * t * t if t < 0.5 else -1 + (4 - 2 * t) * t
+
+        # 生成阅读路径：逐行扫视
+        waypoints: list[tuple[int, int, float]] = []  # (x, y, delay_sec)
+        cx, cy = rand(left, right), rand(top, top + (bottom - top) // 3)
+        line_count = max(3, duration_ms // 600)
+        line_step  = (bottom - top) // line_count
+
+        for _ in range(line_count):
+            row_end = rand(left + (right - left) // 2, right)
+            # 逐步插值从 cx→row_end
+            steps = max(3, rand(4, 8))
+            for s in range(1, steps + 1):
+                t = ease(s / steps)
+                wx = int(cx + (row_end - cx) * t) + rand(-3, 3)
+                wy = cy + rand(-2, 2)
+                waypoints.append((wx, wy, rand(14, 28) / 1000))
+            # 偶尔停顿（模拟阅读有趣的行）
+            if random.random() < 0.3:
+                waypoints.append((row_end, cy, rand(150, 500) / 1000))
+            # 换行
+            cy += line_step + rand(-6, 6)
+            if cy > bottom:
+                break
+            cx = rand(left, left + (right - left) // 3)
+            waypoints.append((cx, cy, rand(40, 80) / 1000))
+
+        # 逐帧分发
+        for x, y, delay in waypoints:
+            self.evaluate(
+                f"document.dispatchEvent(new MouseEvent('mousemove',"
+                f"{{clientX:{x},clientY:{y},bubbles:true,cancelable:true}}));"
+            )
+            time.sleep(delay)
+
     def get_scroll_top(self) -> int:
         """获取当前滚动位置。"""
         result = self.evaluate(

--- a/scripts/xhs/feed_detail.py
+++ b/scripts/xhs/feed_detail.py
@@ -7,6 +7,7 @@ import logging
 import random
 import re
 import time
+import urllib.parse
 
 from .cdp import Page
 from .errors import NoFeedDetailError, PageNotAccessibleError
@@ -19,7 +20,6 @@ from .human import (
     MAX_CLICK_PER_ROUND,
     MIN_SCROLL_DELTA,
     POST_SCROLL,
-    REACTION_TIME,
     READ_TIME,
     SCROLL_WAIT,
     SHORT_READ,
@@ -79,6 +79,7 @@ def get_feed_detail(
     xsec_token: str,
     load_all_comments: bool = False,
     config: CommentLoadConfig | None = None,
+    keyword: str = "篮球",
 ) -> FeedDetailResponse:
     """获取 Feed 详情（含评论）。
 
@@ -107,6 +108,8 @@ def get_feed_detail(
     )
 
     # 导航（含重试）
+    # 注：风控 302→/404 由扩展 auto-fix（自动从搜索页换新 token 重试），
+    # 此处只捕获真正的瞬态错误（网络超时等），风控拦截不重试。
     for attempt in range(3):
         try:
             page.navigate(url)
@@ -114,6 +117,10 @@ def get_feed_detail(
             page.wait_dom_stable()
             break
         except Exception as e:
+            err_str = str(e)
+            # 风控 302 重定向：扩展已尝试 auto-fix，仍失败说明 token/session 问题，直接抛出
+            if "风控拦截" in err_str or "重定向至" in err_str:
+                raise PageNotAccessibleError(f"笔记无法访问（风控/token）: {err_str}") from e
             logger.debug("页面导航重试 #%d: %s", attempt, e)
             time.sleep(0.5 + random.random())
     else:
@@ -121,8 +128,14 @@ def get_feed_detail(
 
     sleep_random(800, 1500)
 
+    # 模拟阅读鼠标轨迹（同步进行，增加行为真实性）
+    try:
+        page.simulate_reading_mouse(random.randint(2000, 4000))
+    except Exception:
+        pass
+
     # 检查页面可访问性（扫码验证时自动等待重试）
-    _check_page_accessible(page, url)
+    _check_page_accessible(page, url, keyword)
 
     # 加载全部评论
     if load_all_comments:
@@ -137,10 +150,13 @@ def get_feed_detail(
 # ========== 页面检查 ==========
 
 
-def _check_page_accessible(page: Page, url: str = "") -> None:
+def _check_page_accessible(page: Page, url: str = "", keyword: str = "篮球") -> None:
     """检查页面是否可访问。
 
-    扫码验证场景：等待 10 秒后自动重新访问，验证消失则继续，否则报错。
+    风控绕过策略（三级重试）：
+      1. 先回首页，再跳目标页（same-origin 导航）
+      2. 若仍触发：在搜索结果页加载后再跳目标页（模拟真实搜索→点击笔记流程）
+      3. 仍失败则抛出异常，提示用户手动扫码
     """
     time.sleep(0.5)
 
@@ -150,26 +166,54 @@ def _check_page_accessible(page: Page, url: str = "") -> None:
 
     text = text.strip()
 
-    # 检测扫码验证（反爬机制触发）→ 等待后重试
     if _is_scan_qrcode_verification(text) and url:
-        logger.warning("触发小红书扫码验证，等待 10 秒后重新访问...")
+        # ── Level 1：首页跳转 ──
+        logger.warning("触发小红书扫码验证，Level-1 重试：先回首页再访问目标...")
         time.sleep(10)
+        page.navigate("https://www.xiaohongshu.com")
+        page.wait_for_load()
+        page.wait_dom_stable()
+        time.sleep(2 + random.random())
         page.navigate(url)
         page.wait_for_load()
         page.wait_dom_stable()
         time.sleep(1)
 
         retry_text = page.get_element_text(ACCESS_ERROR_WRAPPER)
-        if retry_text and _is_scan_qrcode_verification(retry_text.strip()):
-            raise PageNotAccessibleError(
-                "触发了小红书验证，需要在浏览器中扫码完成验证后重试。"
-                "这通常是小红书的反爬机制，请稍后再试或在 Chrome 中手动打开该笔记完成验证"
-            )
         if not retry_text or not retry_text.strip():
-            logger.info("验证已消失，继续加载笔记")
+            logger.info("Level-1 重试成功，继续加载笔记")
             return
-        # 重试后仍有其他错误，继续走下面的关键词检测
-        text = retry_text.strip()
+        if not _is_scan_qrcode_verification(retry_text.strip()):
+            text = retry_text.strip()
+        else:
+            # ── Level 2：搜索跳转 ──
+            search_url = (
+                "https://www.xiaohongshu.com/search_result?"
+                + urllib.parse.urlencode({"keyword": keyword, "type": "51"})
+            )
+            logger.warning(
+                "Level-1 失败，Level-2 重试：搜索「%s」后再访问目标...", keyword
+            )
+            time.sleep(5 + random.random() * 5)
+            page.navigate(search_url)
+            page.wait_for_load()
+            page.wait_dom_stable()
+            time.sleep(3 + random.random() * 2)
+            page.navigate(url)
+            page.wait_for_load()
+            page.wait_dom_stable()
+            time.sleep(1)
+
+            retry_text = page.get_element_text(ACCESS_ERROR_WRAPPER)
+            if not retry_text or not retry_text.strip():
+                logger.info("Level-2 重试成功，继续加载笔记")
+                return
+            if _is_scan_qrcode_verification(retry_text.strip()):
+                raise PageNotAccessibleError(
+                    "触发了小红书验证，需要在浏览器中扫码完成验证后重试。"
+                    "这通常是小红书的反爬机制，请稍后再试或在 Chrome 中手动打开该笔记完成验证"
+                )
+            text = retry_text.strip()
 
     for kw in _INACCESSIBLE_KEYWORDS:
         if kw in text:
@@ -187,7 +231,7 @@ def _is_scan_qrcode_verification(text: str) -> bool:
 # ========== 数据提取 ==========
 
 
-_EXTRACT_DETAIL_JS = """
+_EXTRACT_STATE_JS = """
 (() => {
     if (window.__INITIAL_STATE__ &&
         window.__INITIAL_STATE__.note &&
@@ -198,15 +242,40 @@ _EXTRACT_DETAIL_JS = """
 })()
 """
 
+_EXTRACT_DOM_BODY_JS = """
+(() => {
+    const bodyEl = document.querySelector('#detail-desc');
+    if (!bodyEl) return null;
+    // 先提取话题标签
+    const tags = Array.from(bodyEl.querySelectorAll('a.tag'))
+                      .map(a => a.textContent.trim())
+                      .filter(Boolean);
+    // 克隆后移除 a.tag，再取 textContent（不依赖 CSS layout，后台标签页同样生效）
+    const clone = bodyEl.cloneNode(true);
+    clone.querySelectorAll('a.tag').forEach(el => el.remove());
+    const bodyText = clone.textContent.replace(/\\n{3,}/g, '\\n\\n').trim();
+    if (!bodyText && !tags.length) return null;
+    return {body: bodyText, tags: tags};
+})()
+"""
+
 
 def _extract_feed_detail(page: Page, feed_id: str) -> FeedDetailResponse:
-    """从 __INITIAL_STATE__ 提取 Feed 详情。"""
+    """从 __INITIAL_STATE__ 提取 Feed 详情，轮询最多 10s。
+
+    两阶段提取：
+    1. 等待 __INITIAL_STATE__ 数据就绪（最多 10s）
+    2. 等待 #detail-desc DOM 渲染完成后提取正文（最多 8s）
+       Vue 渲染时序：state 早于 DOM，需分开轮询。
+    """
+    # 阶段 1：等待 __INITIAL_STATE__
+    deadline = time.monotonic() + 10.0
     result = None
-    for _ in range(3):
-        result = page.evaluate(_EXTRACT_DETAIL_JS)
+    while time.monotonic() < deadline:
+        result = page.evaluate(_EXTRACT_STATE_JS)
         if result:
             break
-        time.sleep(0.2)
+        time.sleep(0.3)
 
     if not result:
         raise NoFeedDetailError()
@@ -216,8 +285,22 @@ def _extract_feed_detail(page: Page, feed_id: str) -> FeedDetailResponse:
     if not note_data:
         raise NoFeedDetailError()
 
+    # 阶段 2：等待 #detail-desc 渲染（Vue 异步渲染，state 就绪后 DOM 可能还未填充）
+    dom_deadline = time.monotonic() + 8.0
+    dom_result = None
+    while time.monotonic() < dom_deadline:
+        dom_result = page.evaluate(_EXTRACT_DOM_BODY_JS)
+        if dom_result and isinstance(dom_result, dict) and dom_result.get("body", "").strip():
+            break
+        time.sleep(0.3)
+
+    note = note_data.get("note", {})
+    if dom_result and isinstance(dom_result, dict):
+        note["_domBody"] = dom_result.get("body", "")
+        note["_domTags"] = dom_result.get("tags", [])
+
     return FeedDetailResponse(
-        note=FeedDetail.from_dict(note_data.get("note", {})),
+        note=FeedDetail.from_dict(note),
         comments=CommentList.from_dict(note_data.get("comments", {})),
     )
 
@@ -251,12 +334,13 @@ def _load_all_comments(page: Page, config: CommentLoadConfig) -> None:
     for attempt in range(max_attempts):
         logger.debug("=== 尝试 %d/%d ===", attempt + 1, max_attempts)
 
-        # 检查是否到达底部
-        if _check_end_container(page):
-            count = _get_comment_count(page)
+        # 一次调用同时获取：评论数 + 是否到底
+        state = _check_page_state(page)
+
+        if state["at_end"]:
             logger.info(
                 "检测到 THE END，加载完成: %d 条评论, 点击: %d, 跳过: %d",
-                count,
+                state["count"],
                 total_clicked,
                 total_skipped,
             )
@@ -276,8 +360,7 @@ def _load_all_comments(page: Page, config: CommentLoadConfig) -> None:
                 if c2 > 0 or s2 > 0:
                     sleep_random(*SHORT_READ)
 
-        # 获取当前评论数
-        current_count = _get_comment_count(page)
+        current_count = state["count"]
         if current_count != last_count:
             logger.info("评论增加: %d -> %d", last_count, current_count)
             last_count = current_count
@@ -339,8 +422,13 @@ def _human_scroll(
     Returns:
         (actual_delta, current_scroll_top)
     """
-    before_top = page.get_scroll_top()
-    viewport_height = page.get_viewport_height()
+    # 一次 evaluate 同时获取 scrollTop 和 viewportHeight，减少 bridge 往返
+    state = page.evaluate(
+        "({scrollTop: window.pageYOffset || document.documentElement.scrollTop || 0,"
+        " viewportHeight: window.innerHeight})"
+    )
+    before_top = int(state.get("scrollTop", 0)) if isinstance(state, dict) else page.get_scroll_top()
+    viewport_height = int(state.get("viewportHeight", 768)) if isinstance(state, dict) else page.get_viewport_height()
 
     base_ratio = get_scroll_ratio(speed)
     if large_mode:
@@ -382,10 +470,12 @@ def _scroll_to_comments_area(page: Page) -> None:
 
 
 def _scroll_to_last_comment(page: Page) -> None:
-    """滚动到最后一条评论。"""
-    count = page.get_elements_count(PARENT_COMMENT)
-    if count > 0:
-        page.scroll_nth_element_into_view(PARENT_COMMENT, count - 1)
+    """滚动到最后一条评论（count + scroll 合并为 1 次 evaluate）。"""
+    sel = json.dumps(PARENT_COMMENT)
+    page.evaluate(
+        f"(function(){{const els=document.querySelectorAll({sel});"
+        f"if(els.length>0)els[els.length-1].scrollIntoView({{block:'center',behavior:'smooth'}})}})()"
+    )
 
 
 # ========== DOM 查询 ==========
@@ -424,31 +514,59 @@ def _check_end_container(page: Page) -> bool:
     return "THE END" in upper or "THEEND" in upper
 
 
+def _check_page_state(page: Page) -> dict:
+    """一次 evaluate 同时获取评论数、是否无评论、是否到达底部。
+
+    Returns:
+        {"count": int, "no_comments": bool, "at_end": bool}
+    """
+    sel_parent = json.dumps(PARENT_COMMENT)
+    sel_no = json.dumps(NO_COMMENTS_TEXT)
+    sel_end = json.dumps(END_CONTAINER)
+    result = page.evaluate(
+        f"(function(){{"
+        f"  var count = document.querySelectorAll({sel_parent}).length;"
+        f"  var noText = (document.querySelector({sel_no}) || {{}}).textContent || '';"
+        f"  var endText = ((document.querySelector({sel_end}) || {{}}).textContent || '').toUpperCase();"
+        f"  return {{count: count,"
+        f"    no_comments: noText.indexOf('这是一片荒地') >= 0,"
+        f"    at_end: endText.indexOf('THE END') >= 0 || endText.indexOf('THEEND') >= 0}};"
+        f"}})()"
+    )
+    if isinstance(result, dict):
+        return result
+    return {"count": 0, "no_comments": False, "at_end": False}
+
+
 # ========== 按钮点击 ==========
 
 
 def _click_show_more_buttons(page: Page, max_threshold: int) -> tuple[int, int]:
     """点击"展开N条回复"按钮。
 
+    优化：1 次 evaluate 批量获取所有按钮文本，每次点击用 1 次 evaluate 完成
+    scroll+click，减少 bridge 往返次数。
+
     Returns:
         (clicked, skipped)
     """
-    count = page.get_elements_count(SHOW_MORE_BUTTON)
-    if count == 0:
+    sel = json.dumps(SHOW_MORE_BUTTON)
+
+    # 一次 evaluate 获取所有按钮文本
+    texts = page.evaluate(
+        f"Array.from(document.querySelectorAll({sel})).map(e => e.textContent || '')"
+    )
+    if not texts or not isinstance(texts, list):
         return 0, 0
 
     max_click = MAX_CLICK_PER_ROUND + random.randint(0, MAX_CLICK_PER_ROUND - 1)
     clicked = 0
     skipped = 0
 
-    for i in range(count):
+    for i, text in enumerate(texts):
         if clicked >= max_click:
             break
 
-        # 获取按钮文本
-        text = page.evaluate(
-            f"document.querySelectorAll({json.dumps(SHOW_MORE_BUTTON)})[{i}]?.textContent || ''"
-        )
         if not text:
             continue
 
@@ -464,10 +582,13 @@ def _click_show_more_buttons(page: Page, max_threshold: int) -> tuple[int, int]:
                     skipped += 1
                     continue
 
-        # 滚动到按钮并点击
-        page.scroll_nth_element_into_view(SHOW_MORE_BUTTON, i)
-        sleep_random(*REACTION_TIME)
-        page.evaluate(f"document.querySelectorAll({json.dumps(SHOW_MORE_BUTTON)})[{i}]?.click()")
+        # 一次 evaluate 完成：滚动到按钮 + 点击
+        page.evaluate(
+            f"(function(){{"
+            f"  var el=document.querySelectorAll({sel})[{i}];"
+            f"  if(el){{el.scrollIntoView({{block:'center',behavior:'smooth'}});el.click();}}"
+            f"}})()"
+        )
         sleep_random(*READ_TIME)
         clicked += 1
 

--- a/scripts/xhs/publish.py
+++ b/scripts/xhs/publish.py
@@ -178,8 +178,13 @@ def _navigate_to_publish_page(page: Page) -> None:
 def _click_publish_tab(page: Page, tab_name: str) -> None:
     """点击发布页 TAB（上传图文/上传视频/写长文/发播客）。
 
-    XHS 创作中心反爬：非激活 tab 会用 left/top: -9999px 或 opacity: 1e-05 隐藏，
-    但保留 pointer-events: auto 可点击。所以 selector 不能查可见性，要用属性精确匹配。
+    XHS 创作中心反爬陷阱：
+    - 每个 tab 都有"真 + 假"两份。假 tab 有 data-hp-kind / button-hp-installed
+      属性（hp=honey pot），是反爬陷阱，点击会被标记为机器人 + active 不切换。
+    - 真 tab 是 Vue scoped 元素（data-v-* 属性，含 span.title 子元素），藏在
+      style="left: -9999px; top: -9999px;" 之外的位置，但 pointer-events: auto 可点。
+
+    正确策略：只点没有 hp 标记的真 Vue tab，等待 active class 切换确认。
     """
     deadline = time.monotonic() + 15
     while time.monotonic() < deadline:
@@ -187,29 +192,22 @@ def _click_publish_tab(page: Page, tab_name: str) -> None:
             f"""
             (() => {{
                 const name = {json.dumps(tab_name)};
-                // 策略1: data-hp-kind 属性精确匹配（XHS 给每个 tab 打了 data-hp-kind="creator-tab-<名称>"）
-                let tab = document.querySelector('div.creator-tab[data-hp-kind="creator-tab-' + name + '"]');
-                if (tab) {{
-                    tab.click();
-                    return 'clicked';
-                }}
-
-                // 策略2: 通过 span.title 子元素文字匹配（兼容无 data-hp-kind 的版本）
                 const tabs = document.querySelectorAll({json.dumps(CREATOR_TAB)});
+
+                // 优先策略：排除 honey pot，找真 Vue tab（含 span.title 且无 hp 标记）
                 for (const t of tabs) {{
+                    if (t.hasAttribute('data-hp-kind') || t.hasAttribute('button-hp-installed')) continue;
                     const title = t.querySelector('span.title');
                     if (title && title.textContent.trim() === name) {{
-                        const style = window.getComputedStyle(t);
-                        // 只查 display:none / visibility:hidden（真正不可点）；不查 opacity / position
-                        if (style.display === 'none' || style.visibility === 'hidden') continue;
                         t.click();
                         return 'clicked';
                     }}
                 }}
 
-                // 策略3: textContent 直接匹配（最宽松兜底）
+                // 兜底：所有 tab 中按 span.title 匹配（含 hp 也接受，但仅当真 tab 都找不到时）
                 for (const t of tabs) {{
-                    if (t.textContent.trim() === name) {{
+                    const title = t.querySelector('span.title');
+                    if (title && title.textContent.trim() === name) {{
                         t.click();
                         return 'clicked';
                     }}
@@ -219,6 +217,30 @@ def _click_publish_tab(page: Page, tab_name: str) -> None:
             }})()
             """
         )
+
+        # 等待 active class 切换到目标 tab，确认真切换了（不是被 honey pot 吞了点击）
+        if found == "clicked":
+            switched_deadline = time.monotonic() + 5
+            while time.monotonic() < switched_deadline:
+                is_active = page.evaluate(
+                    f"""
+                    (() => {{
+                        const tabs = document.querySelectorAll({json.dumps(CREATOR_TAB)});
+                        for (const t of tabs) {{
+                            if (t.hasAttribute('data-hp-kind') || t.hasAttribute('button-hp-installed')) continue;
+                            const title = t.querySelector('span.title');
+                            if (title && title.textContent.trim() === {json.dumps(tab_name)}) {{
+                                return t.classList.contains('active');
+                            }}
+                        }}
+                        return false;
+                    }})()
+                    """
+                )
+                if is_active:
+                    return
+                time.sleep(0.2)
+            logger.warning("点击了 %s 但 active class 未切换，可能被 honey pot 拦截", tab_name)
 
         if found == "clicked":
             return

--- a/scripts/xhs/publish.py
+++ b/scripts/xhs/publish.py
@@ -176,50 +176,45 @@ def _navigate_to_publish_page(page: Page) -> None:
 
 
 def _click_publish_tab(page: Page, tab_name: str) -> None:
-    """点击发布页 TAB（上传图文/上传视频）。"""
+    """点击发布页 TAB（上传图文/上传视频/写长文/发播客）。
+
+    XHS 创作中心反爬：非激活 tab 会用 left/top: -9999px 或 opacity: 1e-05 隐藏，
+    但保留 pointer-events: auto 可点击。所以 selector 不能查可见性，要用属性精确匹配。
+    """
     deadline = time.monotonic() + 15
     while time.monotonic() < deadline:
-        # 查找匹配的 TAB（支持多种结构）
         found = page.evaluate(
             f"""
             (() => {{
-                // 策略1: 查找 div.creator-tab（过滤隐藏元素）
-                let tabs = document.querySelectorAll({json.dumps(CREATOR_TAB)});
-                for (const tab of tabs) {{
-                    const titleSpan = tab.querySelector('span.title');
-                    const tabText = titleSpan ? titleSpan.textContent.trim() : tab.textContent.trim();
-                    if (tabText === {json.dumps(tab_name)}) {{
-                        const rect = tab.getBoundingClientRect();
-                        const style = window.getComputedStyle(tab);
-                        // 跳过隐藏或被移出视口的元素
-                        if (rect.width === 0 || rect.height === 0) continue;
-                        if (rect.left < 0 || rect.top < 0) continue;
-                        if (style.display === 'none' || style.visibility === 'hidden') continue;
-                        const x = rect.left + rect.width / 2;
-                        const y = rect.top + rect.height / 2;
-                        const target = document.elementFromPoint(x, y);
-                        if (target === tab || tab.contains(target)) {{
-                            tab.click();
-                            return 'clicked';
-                        }}
-                        return 'blocked';
-                    }}
+                const name = {json.dumps(tab_name)};
+                // 策略1: data-hp-kind 属性精确匹配（XHS 给每个 tab 打了 data-hp-kind="creator-tab-<名称>"）
+                let tab = document.querySelector('div.creator-tab[data-hp-kind="creator-tab-' + name + '"]');
+                if (tab) {{
+                    tab.click();
+                    return 'clicked';
                 }}
-                
-                // 策略2: 查找任意包含目标文本的元素
-                const allElements = document.querySelectorAll('*');
-                for (const el of allElements) {{
-                    if (el.children.length === 0 && el.textContent.trim() === {json.dumps(tab_name)}) {{
-                        const rect = el.getBoundingClientRect();
-                        const style = window.getComputedStyle(el);
-                        if (rect.width === 0 || rect.height === 0) continue;
-                        if (rect.left < 0 || rect.top < 0) continue;
+
+                // 策略2: 通过 span.title 子元素文字匹配（兼容无 data-hp-kind 的版本）
+                const tabs = document.querySelectorAll({json.dumps(CREATOR_TAB)});
+                for (const t of tabs) {{
+                    const title = t.querySelector('span.title');
+                    if (title && title.textContent.trim() === name) {{
+                        const style = window.getComputedStyle(t);
+                        // 只查 display:none / visibility:hidden（真正不可点）；不查 opacity / position
                         if (style.display === 'none' || style.visibility === 'hidden') continue;
-                        el.click();
+                        t.click();
                         return 'clicked';
                     }}
                 }}
-                
+
+                // 策略3: textContent 直接匹配（最宽松兜底）
+                for (const t of tabs) {{
+                    if (t.textContent.trim() === name) {{
+                        t.click();
+                        return 'clicked';
+                    }}
+                }}
+
                 return 'not_found';
             }})()
             """

--- a/scripts/xhs/risk_analyzer.py
+++ b/scripts/xhs/risk_analyzer.py
@@ -6,8 +6,15 @@
 from __future__ import annotations
 
 import json
+import re
 from collections import Counter, defaultdict
 from typing import Any
+
+# regex 兜底：reqBody 可能被截断导致 JSON.parse 失败，用正则直接抓字段
+_RE_RISK_USER = re.compile(r'"isRiskUser"\s*:\s*"([^"]+)"')
+_RE_RISK_REASON = re.compile(r'"isRiskReason"\s*:\s*"([^"]*)"')
+_RE_MATCHED_PATH = re.compile(r'"matchedPath"\s*:\s*"([^"]+)"')
+_RE_I_FIELDS = re.compile(r'"i1[234]"\s*:\s*(\d+)')
 
 
 def analyze(entries: list[dict[str, Any]]) -> dict[str, Any]:
@@ -29,6 +36,10 @@ def analyze(entries: list[dict[str, Any]]) -> dict[str, Any]:
 
     # 按 host 分组
     by_host: Counter[str] = Counter(e.get("host", "") for e in entries)
+
+    # 提前定义信号收集容器（后面 axes 提取过程中也会写）
+    high_signals: list[str] = []
+    warnings: list[str] = []
 
     # ── 检测维度提取 ──────────────────────────────────────────────
     axes: dict[str, Any] = {}
@@ -94,6 +105,48 @@ def analyze(entries: list[dict[str, Any]]) -> dict[str, Any]:
             ),
         }
 
+    # 服务端风控判定（从 APM 上报的 measurement_data 反推 isRiskUser 字段）
+    risk_judgments: list[dict[str, Any]] = []
+    for e in apm_entries:
+        body = e.get("reqBody") or ""
+        if "isRiskUser" not in body:
+            continue
+        users = _RE_RISK_USER.findall(body)
+        reasons = _RE_RISK_REASON.findall(body)
+        paths = _RE_MATCHED_PATH.findall(body)
+        for i, status in enumerate(users):
+            risk_judgments.append({
+                "ts": e.get("tsLabel"),
+                "matchedPath": paths[i] if i < len(paths) else None,
+                "isRiskUser": status,
+                "isRiskReason": reasons[i] if i < len(reasons) else None,
+            })
+    if risk_judgments:
+        user_states = Counter(r["isRiskUser"] for r in risk_judgments)
+        non_pass = [r for r in risk_judgments if r["isRiskUser"] != "pass"]
+        axes["server_risk_judgment"] = {
+            "source": "apm-fe/api/data measurement_data.isRiskUser",
+            "total_judgments": len(risk_judgments),
+            "states": dict(user_states),
+            "non_pass_count": len(non_pass),
+            "evidence": (
+                f"前端 SDK 在 {len(risk_judgments)} 个 API 调用后上报服务端风控判定结果到 APM。"
+                f"状态分布：{dict(user_states)}。"
+                + (f"⚠️ {len(non_pass)} 个非 pass 状态" if non_pass else "全部 pass，未被识别")
+            ),
+            "non_pass_samples": [
+                {"ts": r["ts"], "path": r["matchedPath"], "state": r["isRiskUser"],
+                 "reason": r["isRiskReason"]}
+                for r in non_pass[:5]
+            ],
+        }
+        # 任何非 pass 都是高风险信号
+        for r in non_pass:
+            high_signals.append(
+                f"⚠️ isRiskUser={r['isRiskUser']} reason={r['isRiskReason']} "
+                f"on {r['matchedPath']}"
+            )
+
     # 业务 API 签名
     business_entries = [
         e for e in entries
@@ -120,7 +173,7 @@ def analyze(entries: list[dict[str, Any]]) -> dict[str, Any]:
         }
 
     # Cookie 状态（取最新有 reqFingerprint 的 entry）
-    fp_with_cookie = [e for e in entries if e.get("reqFingerprint", {}).get("cookie")]
+    fp_with_cookie = [e for e in entries if (e.get("reqFingerprint") or {}).get("cookie")]
     if fp_with_cookie:
         latest = fp_with_cookie[-1]["reqFingerprint"]["cookie"]
         axes["cookie_state"] = {
@@ -133,8 +186,6 @@ def analyze(entries: list[dict[str, Any]]) -> dict[str, Any]:
         }
 
     # ── 风险信号 ──────────────────────────────────────────────
-    high_signals: list[str] = []
-    warnings: list[str] = []
 
     for e in entries:
         cat = e.get("category", "")

--- a/scripts/xhs/risk_analyzer.py
+++ b/scripts/xhs/risk_analyzer.py
@@ -1,0 +1,216 @@
+"""XHS NetLog 风控分析。
+
+输入：netlogger 抓到的 entry 列表（dict 数组）
+输出：结构化风控报告（dict）含 risk_level / detection_axes / high_risk_signals
+"""
+from __future__ import annotations
+
+import json
+from collections import Counter, defaultdict
+from typing import Any
+
+
+def analyze(entries: list[dict[str, Any]]) -> dict[str, Any]:
+    """从 netlog entries 反推 XHS 检测维度并给出风控结论。"""
+    if not entries:
+        return {
+            "risk_level": "unknown",
+            "total_requests": 0,
+            "summary": "未采集到任何请求，无法分析",
+            "detection_axes": {},
+            "high_risk_signals": [],
+            "warnings": ["netlog 为空，请确认 netlogger 已启用并执行过浏览/操作"],
+        }
+
+    # 按 category 分组
+    by_cat: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for e in entries:
+        by_cat[e.get("category", "other")].append(e)
+
+    # 按 host 分组
+    by_host: Counter[str] = Counter(e.get("host", "") for e in entries)
+
+    # ── 检测维度提取 ──────────────────────────────────────────────
+    axes: dict[str, Any] = {}
+
+    # 浏览器指纹（shield/webprofile）
+    shield_entries = [
+        e for e in entries
+        if e.get("path", "").startswith("/api/sec/v1/shield/webprofile")
+    ]
+    if shield_entries:
+        first = shield_entries[0]
+        sdk_version = ""
+        platform = ""
+        body = first.get("reqBody") or ""
+        try:
+            parsed = json.loads(body)
+            if isinstance(parsed, dict):
+                sdk_version = parsed.get("sdkVersion", "")
+                platform = parsed.get("platform", "")
+        except Exception:
+            pass
+        axes["browser_fingerprint"] = {
+            "host": first.get("host"),
+            "endpoint": "/api/sec/v1/shield/webprofile",
+            "sdk_version": sdk_version,
+            "platform": platform,
+            "called_count": len(shield_entries),
+            "evidence": (
+                f"Shield SDK {sdk_version} 在本会话上报浏览器指纹 {len(shield_entries)} 次，"
+                "profileData 为加密 hex 串（具体指纹字段已被 XHS 服务端加密）"
+            ),
+        }
+
+    # 行为埋点（t2 / collect）
+    t2_entries = [
+        e for e in entries
+        if e.get("host") == "t2.xiaohongshu.com"
+        and "/api/v2/collect" in e.get("path", "")
+    ]
+    if t2_entries:
+        axes["behavior_tracking"] = {
+            "host": "t2.xiaohongshu.com",
+            "endpoint": "/api/v2/collect",
+            "called_count": len(t2_entries),
+            "protocol": "protobuf (base64)",
+            "evidence": (
+                f"行为采集端点被调用 {len(t2_entries)} 次，"
+                f"占总流量 {len(t2_entries) * 100 // max(len(entries), 1)}%。"
+                "请求体为 base64 编码的 protobuf 二进制"
+            ),
+        }
+
+    # APM 监控（apm-fe）
+    apm_entries = [e for e in entries if e.get("host") == "apm-fe.xiaohongshu.com"]
+    if apm_entries:
+        axes["apm_monitoring"] = {
+            "host": "apm-fe.xiaohongshu.com",
+            "endpoint": "/api/data",
+            "called_count": len(apm_entries),
+            "evidence": (
+                f"APM SDK 上报 {len(apm_entries)} 条事件，包含 sdkSessionId / pageSessionId "
+                "/ sdkSeqId 等会话追踪标识"
+            ),
+        }
+
+    # 业务 API 签名
+    business_entries = [
+        e for e in entries
+        if e.get("host") == "edith.xiaohongshu.com" and e.get("reqFingerprint")
+    ]
+    if business_entries:
+        xs_count = sum(1 for e in business_entries if e["reqFingerprint"].get("has_xs"))
+        xt_count = sum(1 for e in business_entries if e["reqFingerprint"].get("has_xt"))
+        xc_count = sum(1 for e in business_entries if e["reqFingerprint"].get("has_xsCommon"))
+        axes["request_signature"] = {
+            "scheme": (
+                "x-s-common (current)" if xc_count > xs_count else "xs/xt (legacy)"
+            ),
+            "edith_total": len(business_entries),
+            "has_xs": xs_count,
+            "has_xt": xt_count,
+            "has_xsCommon": xc_count,
+            "coverage_pct": round(xc_count * 100 / len(business_entries), 1),
+            "evidence": (
+                f"业务 API {len(business_entries)} 条中，{xc_count} 条带 x-s-common，"
+                f"{xs_count} 条带 xs，{xt_count} 条带 xt。"
+                f"当前签名方案：{'x-s-common 单签名' if xc_count > xs_count else 'xs+xt 双签名（已过时）'}"
+            ),
+        }
+
+    # Cookie 状态（取最新有 reqFingerprint 的 entry）
+    fp_with_cookie = [e for e in entries if e.get("reqFingerprint", {}).get("cookie")]
+    if fp_with_cookie:
+        latest = fp_with_cookie[-1]["reqFingerprint"]["cookie"]
+        axes["cookie_state"] = {
+            "has_a1": latest.get("has_a1"),
+            "has_web_session": latest.get("has_web_session"),
+            "has_webId": latest.get("has_webId"),
+            "has_gid": latest.get("has_gid"),
+            "a1_preview": latest.get("a1_preview"),
+            "web_session_preview": latest.get("web_session_preview"),
+        }
+
+    # ── 风险信号 ──────────────────────────────────────────────
+    high_signals: list[str] = []
+    warnings: list[str] = []
+
+    for e in entries:
+        cat = e.get("category", "")
+        status = e.get("status", 0)
+        if cat == "signature_failure":
+            high_signals.append(
+                f"signature_failure: {e.get('path', '')[:80]} "
+                f"error_code={e.get('errorCode')}"
+            )
+        elif cat == "risk_redirect":
+            high_signals.append(
+                f"risk_redirect: {e.get('path', '')[:60]} -> {e.get('redirectTo', '')[:60]}"
+            )
+        elif status == 999:
+            high_signals.append(
+                f"HTTP 999 (账号/IP 系统级封禁): {e.get('path', '')[:80]}"
+            )
+        elif status in (401, 403, 461):
+            high_signals.append(f"HTTP {status}: {e.get('path', '')[:80]}")
+        elif cat == "cookie_change":
+            cookies = e.get("setCookie") or []
+            if any("acw_tc" in c for c in cookies):
+                high_signals.append(
+                    f"acw_tc cookie 变更：阿里云 WAF 边缘风控可能触发 "
+                    f"({e.get('path', '')[:60]})"
+                )
+            else:
+                warnings.append(
+                    f"cookie 变化: {','.join(cookies[:3])} ({e.get('path', '')[:60]})"
+                )
+
+    # 业务 API 签名覆盖率不足
+    if "request_signature" in axes:
+        cov = axes["request_signature"]["coverage_pct"]
+        if cov < 80:
+            warnings.append(
+                f"x-s-common 签名覆盖率 {cov}% < 80%，"
+                "部分业务 API 未签名（可能是公开端点）"
+            )
+
+    # 行为埋点缺失（自动化可能屏蔽了 t2/collect）
+    if "behavior_tracking" not in axes and len(entries) > 20:
+        warnings.append(
+            "未检测到 t2.xiaohongshu.com/api/v2/collect 调用 —— "
+            "XHS 期望此埋点存在，若被屏蔽反而异常，建议放开"
+        )
+
+    # ── 风险等级判断 ──────────────────────────────────────────
+    if any("signature_failure" in s or "HTTP 999" in s for s in high_signals):
+        risk_level = "high"
+    elif any("HTTP 461" in s or "HTTP 403" in s or "HTTP 401" in s for s in high_signals):
+        risk_level = "medium"
+    elif any("acw_tc" in s or "risk_redirect" in s for s in high_signals):
+        risk_level = "medium"
+    elif warnings:
+        risk_level = "low"
+    else:
+        risk_level = "safe"
+
+    # ── summary ──────────────────────────────────────────
+    summary_parts = [
+        f"本会话采集 {len(entries)} 条请求",
+        f"指纹上报 {len(shield_entries)} 次",
+        f"行为埋点 {len(t2_entries)} 次",
+    ]
+    if high_signals:
+        summary_parts.append(f"高风险信号 {len(high_signals)} 个")
+    summary = "，".join(summary_parts) + "。"
+
+    return {
+        "risk_level": risk_level,
+        "total_requests": len(entries),
+        "summary": summary,
+        "detection_axes": axes,
+        "category_distribution": dict(Counter(e.get("category", "other") for e in entries)),
+        "top_hosts": dict(by_host.most_common(10)),
+        "high_risk_signals": high_signals,
+        "warnings": warnings,
+    }

--- a/scripts/xhs/search.py
+++ b/scripts/xhs/search.py
@@ -15,37 +15,31 @@ from .urls import make_search_url
 
 logger = logging.getLogger(__name__)
 
-# 筛选选项映射表：{筛选组索引: [(标签索引, 文本), ...]}
-_FILTER_OPTIONS: dict[int, list[tuple[int, str]]] = {
-    1: [(1, "综合"), (2, "最新"), (3, "最多点赞"), (4, "最多评论"), (5, "最多收藏")],
-    2: [(1, "不限"), (2, "视频"), (3, "图文")],
-    3: [(1, "不限"), (2, "一天内"), (3, "一周内"), (4, "半年内")],
-    4: [(1, "不限"), (2, "已看过"), (3, "未看过"), (4, "已关注")],
-    5: [(1, "不限"), (2, "同城"), (3, "附近")],
+# 筛选选项映射表：{筛选组索引: [文本, ...]}
+_FILTER_OPTIONS: dict[int, list[str]] = {
+    1: ["综合", "最新", "最多点赞", "最多评论", "最多收藏"],
+    2: ["不限", "视频", "图文"],
+    3: ["不限", "一天内", "一周内", "半年内"],
+    4: ["不限", "已看过", "未看过", "已关注"],
+    5: ["不限", "同城", "附近"],
 }
 
 # 从 __INITIAL_STATE__ 提取搜索结果的 JS
 _EXTRACT_SEARCH_JS = """
 (() => {
-    if (window.__INITIAL_STATE__ &&
-        window.__INITIAL_STATE__.search &&
-        window.__INITIAL_STATE__.search.feeds) {
-        const feeds = window.__INITIAL_STATE__.search.feeds;
-        const feedsData = feeds.value !== undefined ? feeds.value : feeds._value;
-        if (feedsData) {
-            return JSON.stringify(feedsData);
-        }
-    }
-    return "";
+    const s = window.__INITIAL_STATE__?.search;
+    if (!s?.feeds) return "";
+    const data = s.feeds.value !== undefined ? s.feeds.value : s.feeds._value;
+    return data ? JSON.stringify(data) : "";
 })()
 """
 
 
-def _find_internal_option(group_index: int, text: str) -> tuple[int, int]:
-    """查找内部筛选选项索引。
+def _find_internal_option(group_index: int, text: str) -> tuple[int, str]:
+    """查找内部筛选选项。
 
     Returns:
-        (filters_index, tags_index)
+        (filters_index, text)
 
     Raises:
         ValueError: 未找到匹配的选项。
@@ -54,17 +48,15 @@ def _find_internal_option(group_index: int, text: str) -> tuple[int, int]:
     if not options:
         raise ValueError(f"筛选组 {group_index} 不存在")
 
-    for tags_index, option_text in options:
-        if option_text == text:
-            return group_index, tags_index
+    if text in options:
+        return group_index, text
 
-    valid = [t for _, t in options]
-    raise ValueError(f"在筛选组 {group_index} 中未找到 '{text}'，有效值: {valid}")
+    raise ValueError(f"在筛选组 {group_index} 中未找到 '{text}'，有效值: {options}")
 
 
-def _convert_filters(filter_opt: FilterOption) -> list[tuple[int, int]]:
-    """将 FilterOption 转换为内部 (filters_index, tags_index) 列表。"""
-    result: list[tuple[int, int]] = []
+def _convert_filters(filter_opt: FilterOption) -> list[tuple[int, str]]:
+    """将 FilterOption 转换为内部 (filters_index, text) 列表。"""
+    result: list[tuple[int, str]] = []
 
     if filter_opt.sort_by:
         result.append(_find_internal_option(1, filter_opt.sort_by))
@@ -101,10 +93,10 @@ def search_feeds(
     page.wait_for_load()
     page.wait_dom_stable()
 
-    # 等待 __INITIAL_STATE__ 初始化
-    _wait_for_initial_state(page)
+    # 等待 __INITIAL_STATE__.search.feeds 有数据
+    _wait_for_search_feeds(page)
 
-    # 应用筛选条件
+    # 应用筛选条件（若有）
     if filter_option:
         internal_filters = _convert_filters(filter_option)
         if internal_filters:
@@ -116,41 +108,100 @@ def search_feeds(
         raise NoFeedsError()
 
     feeds_data = json.loads(result)
+    if not feeds_data:
+        raise NoFeedsError()
+
     return [Feed.from_dict(f) for f in feeds_data]
 
 
-def _wait_for_initial_state(page: Page, timeout: float = 10.0) -> None:
-    """等待 __INITIAL_STATE__ 就绪。"""
+def _wait_for_search_feeds(page: Page, timeout: float = 15.0) -> None:
+    """等待 __INITIAL_STATE__.search.feeds 有数据。
+
+    Raises:
+        NoFeedsError: 超时仍无数据。
+    """
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
-        ready = page.evaluate("window.__INITIAL_STATE__ !== undefined")
-        if ready:
-            return
-        time.sleep(0.5)
-    logger.warning("等待 __INITIAL_STATE__ 超时")
+        result = page.evaluate(_EXTRACT_SEARCH_JS)
+        if result:
+            try:
+                if json.loads(result):
+                    return
+            except json.JSONDecodeError:
+                pass
+        time.sleep(0.3)
+    raise NoFeedsError()
 
 
-def _apply_filters(page: Page, filters: list[tuple[int, int]]) -> None:
-    """应用筛选条件。"""
-    # 悬停筛选按钮
-    page.hover_element(FILTER_BUTTON)
+def _apply_filters(page: Page, filters: list[tuple[int, str]]) -> None:
+    """应用筛选条件。
 
-    # 等待筛选面板出现
-    deadline = time.monotonic() + 5.0
-    while time.monotonic() < deadline:
-        if page.has_element(FILTER_PANEL):
-            break
-        sleep_random(300, 600)
+    在单次 evaluate 调用内完成：点击筛选按钮 → 等待面板 → 按文本点击各选项
+    → 等待搜索结果刷新。
+    避免多次 WebSocket 连接导致面板关闭的时序问题。
+    """
+    filter_js_list = ", ".join(
+        f'[{idx}, {json.dumps(text)}]' for idx, text in filters
+    )
 
-    # 点击各筛选项
-    for filters_index, tags_index in filters:
-        selector = (
-            f"div.filter-panel div.filters:nth-child({filters_index}) "
-            f"div.tags:nth-child({tags_index})"
-        )
-        page.click_element(selector)
-        sleep_random(300, 600)
+    # 记录当前 feeds 快照，用于检测结果是否已刷新
+    snapshot_js = "JSON.stringify(window.__INITIAL_STATE__?.search?.feeds?.value ?? window.__INITIAL_STATE__?.search?.feeds?._value ?? null)"
 
-    # 等待页面更新
-    page.wait_dom_stable()
-    _wait_for_initial_state(page)
+    script = f"""
+(() => {{
+  return new Promise((resolve, reject) => {{
+    const btn = document.querySelector('div.filter');
+    if (!btn) {{ reject('筛选按钮不存在'); return; }}
+
+    // 记录点击前的 feeds 快照（用于判断结果已刷新）
+    const snapshot = {snapshot_js};
+    btn.click();
+
+    const items = [{filter_js_list}];
+    let attempts = 0;
+
+    // 等待筛选面板出现
+    const panelTimer = setInterval(() => {{
+      const wrapper = document.querySelector('div.filters-wrapper');
+      if (!wrapper) {{
+        if (++attempts > 50) {{ clearInterval(panelTimer); reject('筛选面板等待超时'); }}
+        return;
+      }}
+      clearInterval(panelTimer);
+
+      // 依次点击各筛选项
+      for (const [groupIdx, text] of items) {{
+        const group = wrapper.querySelectorAll('div.filters')[groupIdx - 1];
+        if (!group) {{ reject('筛选组 ' + groupIdx + ' 不存在'); return; }}
+        const tag = Array.from(group.querySelectorAll('div.tags'))
+          .find(el => el.textContent.trim() === text);
+        if (!tag) {{ reject('选项不存在: ' + text); return; }}
+        tag.click();
+      }}
+
+      // 等待搜索结果刷新（feeds 快照变化）
+      let refreshAttempts = 0;
+      const refreshTimer = setInterval(() => {{
+        const current = {snapshot_js};
+        if (current !== snapshot) {{
+          clearInterval(refreshTimer);
+          resolve(null);
+          return;
+        }}
+        if (++refreshAttempts > 60) {{
+          // 超时也继续（结果可能未变化）
+          clearInterval(refreshTimer);
+          resolve(null);
+        }}
+      }}, 100);
+    }}, 100);
+  }});
+}})()
+"""
+    try:
+        page.evaluate(script)
+    except Exception as e:
+        raise ValueError(f"应用筛选失败: {e}") from e
+
+    # 等待 __INITIAL_STATE__ 中有新数据
+    _wait_for_search_feeds(page)

--- a/scripts/xhs/selectors.py
+++ b/scripts/xhs/selectors.py
@@ -16,7 +16,7 @@ LOGIN_ERR_MSG = ".err-msg"
 
 # ========== 首页 / 搜索 ==========
 FILTER_BUTTON = "div.filter"
-FILTER_PANEL = "div.filter-panel"
+FILTER_PANEL = "div.filters-wrapper"
 
 # ========== Feed 详情 ==========
 COMMENTS_CONTAINER = ".comments-container"

--- a/scripts/xhs/types.py
+++ b/scripts/xhs/types.py
@@ -258,6 +258,8 @@ class FeedDetail:
     xsec_token: str = ""
     title: str = ""
     desc: str = ""
+    body: str = ""   # DOM 正文（干净文本，不含 [话题] 标记）
+    tags: list[str] = field(default_factory=list)  # 话题标签列表
     type: str = ""
     time: int = 0
     ip_location: str = ""
@@ -272,6 +274,8 @@ class FeedDetail:
             xsec_token=d.get("xsecToken", ""),
             title=d.get("title", ""),
             desc=d.get("desc", ""),
+            body=d.get("_domBody", ""),
+            tags=d.get("_domTags", []),
             type=d.get("type", ""),
             time=d.get("time", 0),
             ip_location=d.get("ipLocation", ""),
@@ -285,6 +289,8 @@ class FeedDetail:
             "noteId": self.note_id,
             "title": self.title,
             "desc": self.desc,
+            "body": self.body,
+            "tags": self.tags,
             "type": self.type,
             "time": self.time,
             "ipLocation": self.ip_location,

--- a/skills/xhs-explore/SKILL.md
+++ b/skills/xhs-explore/SKILL.md
@@ -141,6 +141,28 @@ python scripts/cli.py get-feed-detail \
 
 输出包含：笔记完整内容、图片列表、互动数据、评论列表。
 
+### 批量获取详情的防风控策略
+
+**重要**：小红书会在同一 session 连续访问 4~5 篇详情后触发扫码验证（风控机制）。
+批量获取时必须每 3 篇插入一次随机等待，模拟人类阅读节奏。
+
+```bash
+# 正确做法：每 3 篇后 sleep 10~20 秒
+python scripts/cli.py get-feed-detail --feed-id ID1 --xsec-token TOKEN1 && \
+python scripts/cli.py get-feed-detail --feed-id ID2 --xsec-token TOKEN2 && \
+python scripts/cli.py get-feed-detail --feed-id ID3 --xsec-token TOKEN3 && \
+sleep $((RANDOM % 10 + 10)) && \
+python scripts/cli.py get-feed-detail --feed-id ID4 --xsec-token TOKEN4 && \
+python scripts/cli.py get-feed-detail --feed-id ID5 --xsec-token TOKEN5 && \
+python scripts/cli.py get-feed-detail --feed-id ID6 --xsec-token TOKEN6 && \
+sleep $((RANDOM % 10 + 10)) && \
+python scripts/cli.py get-feed-detail --feed-id ID7 --xsec-token TOKEN7
+```
+
+- 每组不超过 3 篇
+- 组间等待 10~20 秒（用 `$((RANDOM % 10 + 10))` 随机化）
+- 不要把所有命令无间隔地串在一起
+
 ### 获取用户主页
 
 ```bash

--- a/skills/xhs-explore/SKILL.md
+++ b/skills/xhs-explore/SKILL.md
@@ -188,3 +188,12 @@ python scripts/cli.py user-profile \
 - **搜索无结果**：建议更换关键词或调整筛选条件。
 - **笔记不可访问**：可能是私密笔记或已删除，提示用户。
 - **用户主页不可访问**：用户可能已注销或设置隐私。
+
+## 风控数据 (NetLog)
+
+如需了解当前会话被 XHS 检测的维度，可调用：
+
+- `python scripts/cli.py get-netlog [--limit N]` —— 获取原始 entries
+- `python scripts/cli.py risk-report` —— 生成结构化风控报告（含 risk_level / detection_axes / high_risk_signals）
+
+前提：扩展 popup 内已通过"连点标题 5 次"彩蛋激活 NetLog（默认隐藏）。


### PR DESCRIPTION
## Summary

在浏览器扩展中加入小红书网页版网络监听能力（NetLogger），**反向推导 XHS 用于检测自动化的完整维度体系**，并通过 CLI 把数据暴露给 Claude / LLM 让自动化操作时能实时判断是否被风控。

### 核心能力

- 🎯 **`isRiskUser` 实时风控判定** — 从 APM 上报中提取服务端风控判定（pass/risk/limit/block），自动化操作可主动监听 + 规避
- 🛡️ **9 个检测维度可见** — Shield SDK 指纹 / 远程脚本 / 行为埋点 / APM / x-s-common 签名 / Cookie / CAS SSO / racing A/B / ros-upload
- 🔍 **Honey pot 反爬陷阱识别** — XHS 创作中心每个 tab 真+假两份，识别 `data-hp-kind` 标记并规避
- 🥚 **彩蛋激活** — popup 标题连点 5 次激活，默认对普通使用零感知

## 关键 Commits (从新到旧)

```
docs: 回填 spec 附录 - 反爬体系深度反推
fix(publish): 排除 honey pot 反爬陷阱 (data-hp-kind / button-hp-installed)
fix(publish): 适配 -9999px / opacity:1e-05 tab 隐藏
feat(risk-report): server_risk_judgment 维度 + i12/i13/i14 评分
fix(extension): interceptor.js 4 处中文字符串嵌套双引号 SyntaxError
fix(netlogger): Response.prototype hook 绕过 XHS _garp fetch wrapper
fix(netlogger): respBody 抓取链路修复 + 8 个累积 issue
feat(cli): get-netlog / risk-report 命令
feat(extension): popup 彩蛋激活 + 时序流 / 检测维度双 tab + JSON 导出
feat(extension): netlogger 分类 + cookieDiff + interceptor 全量 hook
feat(extension): webRequest 4 阶段监听 + 环形缓冲 + storage
chore: netlogger 实施前基线整合
docs: 设计文档 + 实施计划
```

## 反爬反推主要发现

| 检测维度 | 实测证据 |
|---|---|
| **isRiskUser 服务端判定** | apm-fe/api/data 含 measurement_data.isRiskUser=pass/risk/limit/block + i12/i13/i14 评分 |
| **Shield SDK 4.3.5** | as.xiaohongshu.com/api/sec/v1/shield/webprofile 加密 profileData hex |
| **远程脚本下发** | as/api/sec/v1/scripting (JSONP) — callFrom 按场景下发不同检测 JS |
| **行为埋点 wapT** | t2.xiaohongshu.com/api/v2/collect (protobuf, 占总流量 44%) |
| **CAS SSO 5 cookie 链** | 创作中心独立 session：customer-sso-sid / x-user-id-creator / access-token-creator / galaxy_creator_session_id / galaxy.creator.beaker.session.id |
| **x-s-common 单签名** | 旧 xs/xt 已废弃（实测 0 命中），现版 x-s-common 92% 覆盖业务 API |
| **acw_tc 跨子域追踪** | 阿里云 WAF 统一会话指纹，每次跨子域跳转重新颁发 |
| **ros-upload 上传链路** | spectrum OSS bucket + speedTestToken CDN 选优 + tgw_l7_route SLB 路由 |
| **Honey pot tab 陷阱** | 每个 tab 真+假两份，假 tab 有 data-hp-kind/button-hp-installed 属性 |
| **racing A/B 分流** | 按 device_id + user_id 分配不同检测规则版本 |

## 端到端冒烟（详见 spec 附录）

| 场景 | 请求数 | isRiskUser | risk_level |
|---|---|---|---|
| 搜索 \"claude\" | 146 | 全 pass (40/40) | medium (acw_tc 变更) |
| 搜索 \"ai\" | 99 | 全 pass (27/27) | safe |
| 创作中心 fill-publish | 284 | 全 pass (7/7) | medium (acw_tc 变更) |

## Test plan

- [x] reload 扩展 + popup 标题连点 5 次激活 NetLog 卡片
- [ ] 浏览 xhs 主站 30s，popup 时序流实时刷新
- [ ] popup 切到\"检测维度\" tab，看到 fingerprint_upload / business_api / page_nav 等分组
- [ ] 跑 \`python scripts/cli.py risk-report\` 看 JSON 输出含 server_risk_judgment + isRiskUser 字段
- [ ] 跑 \`python scripts/cli.py get-netlog --limit 50\` 看原始 entries
- [ ] 跑 \`python scripts/cli.py fill-publish\` 进创作中心，验证 honey pot tab 规避 + 上传成功
- [ ] 故意访问无 xsec_token URL（如 \`/explore/650000000000000000000000\`），验证 risk_redirect / signature_failure 分类
- [ ] 验证 NetLog 启用状态跨浏览器重启持久化

## 文档

- 设计文档：\`docs/superpowers/specs/2026-05-19-xhs-netlogger-design.md\`
- 实施计划：\`docs/superpowers/plans/2026-05-19-xhs-netlogger.md\`
- spec 附录含完整反爬反推 + 实施期间 7 个 bug 修复总结 + 反爬规避总策略表

🤖 Generated with [Claude Code](https://claude.com/claude-code)