### PR TITLE
fix(publish): 适配 XHS 反爬升级 + dispatchEvent + 多层响应捕获

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -822,6 +822,29 @@ function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
 
 // ───────────────────────── 真实鼠标点击（chrome.debugger + CDP） ──────
 
+// 在视口绝对坐标 (x, y) 派发真实鼠标事件序列：mouseMoved（轨迹）+ mousePressed + mouseReleased。
+// 真事件走渲染层，能穿透 closed shadow DOM；JS 合成事件做不到。
+async function _dispatchRealClickAt(target, x, y) {
+  const startX = x - 20;
+  const startY = y - 45;
+  const steps = 5;
+  for (let i = 1; i <= steps; i++) {
+    const t = i / steps;
+    await chrome.debugger.sendCommand(target, "Input.dispatchMouseEvent", {
+      type: "mouseMoved",
+      x: Math.round(startX + (x - startX) * t),
+      y: Math.round(startY + (y - startY) * t),
+      button: "none", buttons: 0, modifiers: 0,
+    });
+    await sleep(8);
+  }
+
+  const base = { x, y, button: "left", buttons: 1, clickCount: 1, modifiers: 0 };
+  await chrome.debugger.sendCommand(target, "Input.dispatchMouseEvent", { ...base, type: "mousePressed" });
+  await sleep(30);
+  await chrome.debugger.sendCommand(target, "Input.dispatchMouseEvent", { ...base, type: "mouseReleased", buttons: 0 });
+}
+
 async function cmdClickViaDebugger(method, { selector, index, text }) {
   const tab = await getOrOpenXhsTab();
   const target = { tabId: tab.id };
@@ -836,6 +859,8 @@ async function cmdClickViaDebugger(method, { selector, index, text }) {
     findExpr = `document.querySelector(${JSON.stringify(selector)})`;
   }
 
+  // 防御性 detach：清掉残留 attach 状态
+  await chrome.debugger.detach(target).catch(() => {});
   await chrome.debugger.attach(target, "1.3");
   try {
     // 先滚动元素到视口中心，再取坐标
@@ -853,25 +878,7 @@ async function cmdClickViaDebugger(method, { selector, index, text }) {
     const pos = evalResult?.result?.value;
     if (!pos) throw new Error(`元素不存在: ${JSON.stringify({ selector, index, text })}`);
 
-    // 鼠标轨迹：从上方偏移处移动到目标点（5 步）
-    const startX = pos.x - 20;
-    const startY = pos.y - 45;
-    const steps = 5;
-    for (let i = 1; i <= steps; i++) {
-      const t = i / steps;
-      await chrome.debugger.sendCommand(target, "Input.dispatchMouseEvent", {
-        type: "mouseMoved",
-        x: Math.round(startX + (pos.x - startX) * t),
-        y: Math.round(startY + (pos.y - startY) * t),
-        button: "none", buttons: 0, modifiers: 0,
-      });
-      await sleep(8);
-    }
-
-    const base = { x: pos.x, y: pos.y, button: "left", buttons: 1, clickCount: 1, modifiers: 0 };
-    await chrome.debugger.sendCommand(target, "Input.dispatchMouseEvent", { ...base, type: "mousePressed" });
-    await sleep(30);
-    await chrome.debugger.sendCommand(target, "Input.dispatchMouseEvent", { ...base, type: "mouseReleased", buttons: 0 });
+    await _dispatchRealClickAt(target, pos.x, pos.y);
   } finally {
     await chrome.debugger.detach(target).catch(() => {});
   }

--- a/extension/content.js
+++ b/extension/content.js
@@ -10,10 +10,16 @@
  */
 
 // ── interceptor.js (MAIN world) → background.js 桥接 ────────
+// 注意：扩展 reload 后老 content script 仍在页面，但 chrome.runtime context 失效。
+// 此时 sendMessage 会同步抛 "Extension context invalidated"（.catch 抓不到），
+// 必须先用 chrome.runtime?.id 检测 context 是否还存活。
 window.addEventListener("message", (e) => {
   if (e.source !== window) return;
   if (e.data?.source !== "xhs-interceptor" || e.data?.type !== "BLOCK_EVENT") return;
-  chrome.runtime.sendMessage({ type: "XHS_BLOCK_EVENT", event: e.data.event }).catch(() => {});
+  if (!chrome.runtime?.id) return; // context invalidated, orphan content script
+  try {
+    chrome.runtime.sendMessage({ type: "XHS_BLOCK_EVENT", event: e.data.event }).catch(() => {});
+  } catch (_) { /* runtime gone between guard and call */ }
 });
 
 // 通知 interceptor.js：content.js 已就绪，可以 flush 排队的事件
@@ -229,11 +235,13 @@ function sleep(ms) {
 // MAIN world interceptor → content (postMessage) → background (runtime)
 window.addEventListener("message", (e) => {
   if (e.source !== window) return;
-  if (e.data?.source === "xhs-netlog-intercept") {
+  if (e.data?.source !== "xhs-netlog-intercept") return;
+  if (!chrome.runtime?.id) return; // extension reloaded, content script orphaned
+  try {
     chrome.runtime.sendMessage({
       type: "NETLOG_INTERCEPTOR_ENTRY",
       payload: e.data,
     }).catch(() => {});
-  }
+  } catch (_) { /* runtime gone between guard and call */ }
 });
 

--- a/scripts/xhs/errors.py
+++ b/scripts/xhs/errors.py
@@ -42,6 +42,19 @@ class PublishError(XHSError):
     """发布失败。"""
 
 
+class AccountRiskControlError(PublishError):
+    """账号被风控，无法发布。
+
+    XHS 后端业务错误码（HTTP 200 + code≠0）：
+      - -9136: 因违反社区规范禁止发笔记
+    """
+
+    def __init__(self, code: int, msg: str) -> None:
+        self.code = code
+        self.msg = msg
+        super().__init__(f"账号被风控（code={code}）：{msg}")
+
+
 class TitleTooLongError(PublishError):
     """标题超过长度限制。"""
 

--- a/scripts/xhs/publish.py
+++ b/scripts/xhs/publish.py
@@ -121,39 +121,56 @@ def click_publish_button(page: Page) -> None:
     更可靠：不依赖坐标、不依赖 chrome.debugger、不会被反爬的鼠标事件指纹检测。
 
     流程：
-      1. 注入 fetch/XHR 拦截器捕获发布 API 响应
+      1. 注入 3 层响应捕获（XHR/fetch 内容匹配 + console hook + DOM toast 观察器）
       2. host.dispatchEvent(new CustomEvent('publish')) 触发发布
-      3. 轮询拦截结果，识别业务错误码（-9136 = 账号风控）
+      3. 轮询任一层捕获到的结果，识别业务错误码（-9136 = 账号风控）
 
     Raises:
         PublishError: 未找到 host 或按钮被禁用。
         AccountRiskControlError: 账号被风控（如 code=-9136）。
     """
-    # 1) 注入响应拦截器（XHS 用 axios→XMLHttpRequest，必须 wrap XHR；fetch 兜底）
+    # 1) 注入多层响应捕获
+    #    XHS 自家有多层 XHR 拦截嵌套（s1-main / interceptor.js / axios），URL pattern
+    #    无法可靠匹配；用"响应内容标志"判定 + console.error hook + DOM toast 观察器三管齐下。
     page.evaluate(
         """
         (() => {
             window.__xhsPublishResult = null;
 
-            function isPublishApi(url) {
-                if (!url) return false;
-                return url.includes('/note/create')
-                    || url.includes('/publish/')
-                    || url.includes('publish_note')
-                    || url.includes('/note/post')
-                    || url.includes('/api/galaxy/');
+            // 内容标志：成功响应含 note_id；失败响应含 HTTPBizError 或 -913x 风控码或"禁止发笔记"
+            function looksLikePublishResp(body) {
+                if (!body) return false;
+                return body.includes('HTTPBizError')
+                    || /"code":\\s*-913\\d/.test(body)
+                    || body.includes('禁止发笔记')
+                    || /"note_id":\\s*"[^"]+"/.test(body);
             }
 
-            function capture(url, status, bodyText) {
+            function capture(source, info) {
+                if (window.__xhsPublishResult) return;  // first-wins
+                window.__xhsPublishResult = {source, ...info};
+            }
+
+            function captureFromBody(source, url, status, body) {
+                if (window.__xhsPublishResult) return;
+                if (!looksLikePublishResp(body)) return;
                 try {
-                    const j = JSON.parse(bodyText);
-                    window.__xhsPublishResult = {url, status, ...j};
+                    const j = JSON.parse(body);
+                    capture(source, {url, status, ...j});
                 } catch (e) {
-                    window.__xhsPublishResult = {url, status, raw: (bodyText || '').slice(0, 500)};
+                    // body 不是顶层 JSON，尝试 regex 抽取 code/msg
+                    const codeMatch = body.match(/"code":\\s*(-?\\d+)/);
+                    const msgMatch = body.match(/"msg":\\s*"([^"]+)"/);
+                    capture(source, {
+                        url, status,
+                        code: codeMatch ? parseInt(codeMatch[1], 10) : null,
+                        msg: msgMatch ? msgMatch[1] : null,
+                        raw: body.slice(0, 500),
+                    });
                 }
             }
 
-            // wrap XHR
+            // Layer 1: XHR — 内容标志判定，绕开 URL pattern 不可靠的问题
             const origOpen = XMLHttpRequest.prototype.open;
             const origSend = XMLHttpRequest.prototype.send;
             XMLHttpRequest.prototype.open = function(method, url) {
@@ -161,27 +178,70 @@ def click_publish_button(page: Page) -> None:
                 return origOpen.apply(this, arguments);
             };
             XMLHttpRequest.prototype.send = function() {
-                if (isPublishApi(this.__xhsPubUrl)) {
-                    this.addEventListener('loadend', () => {
-                        capture(this.__xhsPubUrl, this.status, this.responseText || '');
-                    });
-                }
+                this.addEventListener('loadend', () => {
+                    captureFromBody('xhr', this.__xhsPubUrl, this.status, this.responseText || '');
+                });
                 return origSend.apply(this, arguments);
             };
 
-            // wrap fetch (兜底)
+            // Layer 2: fetch — 同样内容判定
             const origFetch = window.fetch;
             window.fetch = async function(...args) {
                 const url = typeof args[0] === 'string' ? args[0] : args[0].url;
                 const resp = await origFetch.apply(this, args);
-                if (isPublishApi(url)) {
-                    try {
-                        const txt = await resp.clone().text();
-                        capture(url, resp.status, txt);
-                    } catch (e) {}
-                }
+                try {
+                    const txt = await resp.clone().text();
+                    captureFromBody('fetch', url, resp.status, txt);
+                } catch (e) {}
                 return resp;
             };
+
+            // Layer 3: console hook — XHS publish module 失败时打印 "[发布失败] HTTPBizError: ..."
+            ['error', 'log', 'warn'].forEach((method) => {
+                const orig = console[method];
+                console[method] = function(...args) {
+                    const txt = args.map((a) => {
+                        if (typeof a === 'string') return a;
+                        if (a && typeof a === 'object') {
+                            try { return JSON.stringify(a); } catch (e) { return String(a); }
+                        }
+                        return String(a);
+                    }).join(' ');
+                    if (txt.includes('HTTPBizError') || txt.includes('发布失败')) {
+                        const codeMatch = txt.match(/"code":\\s*(-?\\d+)/);
+                        const msgMatch = txt.match(/"msg":\\s*"([^"]+)"/);
+                        if (codeMatch) {
+                            capture('console', {
+                                code: parseInt(codeMatch[1], 10),
+                                msg: msgMatch ? msgMatch[1] : '发布失败',
+                                raw_console: txt.slice(0, 800),
+                            });
+                        }
+                    }
+                    return orig.apply(this, args);
+                };
+            });
+
+            // Layer 4: DOM MutationObserver — toast 出现"违反/违规/禁止发笔记"等关键词
+            const RISK_KW = /违反|违规|禁止发笔记|审核未通过|账号异常|无法发布/;
+            const obs = new MutationObserver((muts) => {
+                if (window.__xhsPublishResult) return;
+                muts.forEach((m) => {
+                    m.addedNodes.forEach((n) => {
+                        if (n.nodeType !== 1) return;
+                        const txt = (n.textContent || '').trim();
+                        if (txt.length === 0 || txt.length > 300) return;
+                        if (!RISK_KW.test(txt)) return;
+                        capture('toast', {
+                            code: -9136,  // 默认风控码
+                            msg: txt,
+                            cls: (n.className || '').toString().slice(0, 80),
+                        });
+                    });
+                });
+            });
+            obs.observe(document.body, {childList: true, subtree: true});
+            window.__xhsPublishObs = obs;
         })()
         """
     )
@@ -213,22 +273,31 @@ def click_publish_button(page: Page) -> None:
         time.sleep(0.3)
 
     if not result:
-        logger.warning("15s 内未捕获到发布 API 响应，无法确认发布是否成功")
+        logger.warning("15s 内未捕获到任何发布反馈（XHR/console/toast 都没匹配）")
         time.sleep(2)
         return
 
     # 4) 解析业务码
+    source = result.get("source", "unknown")
     code = result.get("code")
     msg = result.get("msg", "")
     success = result.get("success")
+    logger.info("捕获发布响应（来源=%s code=%s msg=%r）", source, code, msg)
 
     if code == 0 or success is True:
         logger.info("发布成功")
         time.sleep(2)
         return
 
-    if code == -9136:
-        raise AccountRiskControlError(code, msg or "因违反社区规范禁止发笔记")
+    # XHS 风控类业务码（-913x 段）+ 关键词兜底
+    is_risk_control = (
+        (code is not None and -9140 <= code <= -9130)
+        or "违反" in (msg or "")
+        or "禁止发笔记" in (msg or "")
+        or "违规" in (msg or "")
+    )
+    if is_risk_control:
+        raise AccountRiskControlError(code or -9136, msg or "账号被风控")
 
     raise PublishError(f"发布失败：code={code} msg={msg!r}")
 

--- a/scripts/xhs/publish.py
+++ b/scripts/xhs/publish.py
@@ -9,7 +9,13 @@ import re
 import time
 
 from .cdp import Page
-from .errors import ContentTooLongError, PublishError, TitleTooLongError, UploadTimeoutError
+from .errors import (
+    AccountRiskControlError,
+    ContentTooLongError,
+    PublishError,
+    TitleTooLongError,
+    UploadTimeoutError,
+)
 from .selectors import (
     CONTENT_EDITOR,
     CONTENT_LENGTH_ERROR,
@@ -108,35 +114,123 @@ def fill_publish_form(page: Page, content: PublishImageContent) -> None:
 
 
 def click_publish_button(page: Page) -> None:
-    """点击发布按钮。
+    """触发发布。
 
-    用文本内容精确匹配，避免点到旁边的"发布笔记"下拉按钮。
+    XHS 把发布/暂存按钮包成 <xhs-publish-btn> Vue web component + closed shadow DOM。
+    host 上挂着 'publish' 自定义事件 ——直接 dispatchEvent 比坐标点击 + CDP 真鼠标
+    更可靠：不依赖坐标、不依赖 chrome.debugger、不会被反爬的鼠标事件指纹检测。
+
+    流程：
+      1. 注入 fetch/XHR 拦截器捕获发布 API 响应
+      2. host.dispatchEvent(new CustomEvent('publish')) 触发发布
+      3. 轮询拦截结果，识别业务错误码（-9136 = 账号风控）
 
     Raises:
-        PublishError: 点击失败。
+        PublishError: 未找到 host 或按钮被禁用。
+        AccountRiskControlError: 账号被风控（如 code=-9136）。
     """
-    clicked = page.evaluate(
+    # 1) 注入响应拦截器（XHS 用 axios→XMLHttpRequest，必须 wrap XHR；fetch 兜底）
+    page.evaluate(
         """
         (() => {
-            // 找文本内容精确为"发布"的 bg-red 按钮（排除"发布笔记"等）
-            const btns = document.querySelectorAll('button.bg-red');
-            for (const btn of btns) {
-                const span = btn.querySelector('span');
-                const text = (span ? span.textContent : btn.textContent).trim();
-                if (text === '发布') {
-                    btn.scrollIntoView({block: 'center'});
-                    btn.click();
-                    return true;
+            window.__xhsPublishResult = null;
+
+            function isPublishApi(url) {
+                if (!url) return false;
+                return url.includes('/note/create')
+                    || url.includes('/publish/')
+                    || url.includes('publish_note')
+                    || url.includes('/note/post')
+                    || url.includes('/api/galaxy/');
+            }
+
+            function capture(url, status, bodyText) {
+                try {
+                    const j = JSON.parse(bodyText);
+                    window.__xhsPublishResult = {url, status, ...j};
+                } catch (e) {
+                    window.__xhsPublishResult = {url, status, raw: (bodyText || '').slice(0, 500)};
                 }
             }
-            return false;
+
+            // wrap XHR
+            const origOpen = XMLHttpRequest.prototype.open;
+            const origSend = XMLHttpRequest.prototype.send;
+            XMLHttpRequest.prototype.open = function(method, url) {
+                this.__xhsPubUrl = url;
+                return origOpen.apply(this, arguments);
+            };
+            XMLHttpRequest.prototype.send = function() {
+                if (isPublishApi(this.__xhsPubUrl)) {
+                    this.addEventListener('loadend', () => {
+                        capture(this.__xhsPubUrl, this.status, this.responseText || '');
+                    });
+                }
+                return origSend.apply(this, arguments);
+            };
+
+            // wrap fetch (兜底)
+            const origFetch = window.fetch;
+            window.fetch = async function(...args) {
+                const url = typeof args[0] === 'string' ? args[0] : args[0].url;
+                const resp = await origFetch.apply(this, args);
+                if (isPublishApi(url)) {
+                    try {
+                        const txt = await resp.clone().text();
+                        capture(url, resp.status, txt);
+                    } catch (e) {}
+                }
+                return resp;
+            };
         })()
         """
     )
-    if not clicked:
-        raise PublishError("未找到发布按钮")
-    time.sleep(3)
-    logger.info("发布完成")
+
+    # 2) dispatchEvent 触发发布
+    fire_result = page.evaluate(
+        """
+        (() => {
+            const host = document.querySelector('xhs-publish-btn[is-publish="true"]');
+            if (!host) return 'not_found';
+            if (host.getAttribute('submit-disabled') === 'true') return 'disabled';
+            host.dispatchEvent(new CustomEvent('publish', {bubbles: true, cancelable: true}));
+            return 'fired';
+        })()
+        """
+    )
+    if fire_result == "not_found":
+        raise PublishError("未找到 <xhs-publish-btn> 发布按钮容器")
+    if fire_result == "disabled":
+        raise PublishError("发布按钮 submit-disabled=true，不可发布")
+
+    # 3) 轮询等待 publish API 响应（15s 超时）
+    deadline = time.monotonic() + 15
+    result = None
+    while time.monotonic() < deadline:
+        result = page.evaluate("window.__xhsPublishResult")
+        if result:
+            break
+        time.sleep(0.3)
+
+    if not result:
+        logger.warning("15s 内未捕获到发布 API 响应，无法确认发布是否成功")
+        time.sleep(2)
+        return
+
+    # 4) 解析业务码
+    code = result.get("code")
+    msg = result.get("msg", "")
+    success = result.get("success")
+
+    if code == 0 or success is True:
+        logger.info("发布成功")
+        time.sleep(2)
+        return
+
+    if code == -9136:
+        raise AccountRiskControlError(code, msg or "因违反社区规范禁止发笔记")
+
+    raise PublishError(f"发布失败：code={code} msg={msg!r}")
 
 
 def save_as_draft(page: Page) -> None:
@@ -178,13 +272,19 @@ def _navigate_to_publish_page(page: Page) -> None:
 def _click_publish_tab(page: Page, tab_name: str) -> None:
     """点击发布页 TAB（上传图文/上传视频/写长文/发播客）。
 
-    XHS 创作中心反爬陷阱：
-    - 每个 tab 都有"真 + 假"两份。假 tab 有 data-hp-kind / button-hp-installed
-      属性（hp=honey pot），是反爬陷阱，点击会被标记为机器人 + active 不切换。
-    - 真 tab 是 Vue scoped 元素（data-v-* 属性，含 span.title 子元素），藏在
-      style="left: -9999px; top: -9999px;" 之外的位置，但 pointer-events: auto 可点。
+    XHS 创作中心反爬升级版 —— 每个 tab 渲染 3 份：
 
-    正确策略：只点没有 hp 标记的真 Vue tab，等待 active class 切换确认。
+    1. "屏外诱饵"：Vue scoped (data-v-*)，藏在 `left:-9999px; top:-9999px`，
+       看起来像真 tab 但**不绑事件**，点了 active 不切换。**没有 hp 属性**所以
+       老代码会把它当真 tab 误点。
+    2. "明显 honey pot"：带 data-hp-kind + button-hp-installed，
+       inset 在视口内但 opacity:1e-05 + z-index:-1，点了被标机器人。
+    3. **真 tab**：Vue scoped + 在视口内 + 带 **data-hp-bound="1"**
+       （XHS 反爬框架"已绑定真实事件"的标记）。
+
+    正确策略：找 `data-hp-bound="1"` 且无 hp 陷阱属性的 Vue tab；用 active class
+    切换确认。
+
     """
     deadline = time.monotonic() + 15
     while time.monotonic() < deadline:
@@ -194,23 +294,27 @@ def _click_publish_tab(page: Page, tab_name: str) -> None:
                 const name = {json.dumps(tab_name)};
                 const tabs = document.querySelectorAll({json.dumps(CREATOR_TAB)});
 
-                // 优先策略：排除 honey pot，找真 Vue tab（含 span.title 且无 hp 标记）
+                // 真 tab：有 data-hp-bound + 无 hp 陷阱属性 + 在视口里
+                for (const t of tabs) {{
+                    if (t.hasAttribute('data-hp-kind') || t.hasAttribute('button-hp-installed')) continue;
+                    if (!t.hasAttribute('data-hp-bound')) continue;
+                    const title = t.querySelector('span.title');
+                    if (!title || title.textContent.trim() !== name) continue;
+                    const r = t.getBoundingClientRect();
+                    if (r.left < -1000 || r.top < -1000) continue;
+                    t.click();
+                    return 'clicked';
+                }}
+
+                // 兜底 1：无 hp 陷阱属性 + 在视口内（兼容 XHS 未来去掉 data-hp-bound）
                 for (const t of tabs) {{
                     if (t.hasAttribute('data-hp-kind') || t.hasAttribute('button-hp-installed')) continue;
                     const title = t.querySelector('span.title');
-                    if (title && title.textContent.trim() === name) {{
-                        t.click();
-                        return 'clicked';
-                    }}
-                }}
-
-                // 兜底：所有 tab 中按 span.title 匹配（含 hp 也接受，但仅当真 tab 都找不到时）
-                for (const t of tabs) {{
-                    const title = t.querySelector('span.title');
-                    if (title && title.textContent.trim() === name) {{
-                        t.click();
-                        return 'clicked';
-                    }}
+                    if (!title || title.textContent.trim() !== name) continue;
+                    const r = t.getBoundingClientRect();
+                    if (r.left < -1000 || r.top < -1000) continue;
+                    t.click();
+                    return 'clicked';
                 }}
 
                 return 'not_found';
@@ -218,29 +322,33 @@ def _click_publish_tab(page: Page, tab_name: str) -> None:
             """
         )
 
-        # 等待 active class 切换到目标 tab，确认真切换了（不是被 honey pot 吞了点击）
+        # 等待 active class 切换：检查真正 active 的 tab title 是否 == 目标
         if found == "clicked":
             switched_deadline = time.monotonic() + 5
             while time.monotonic() < switched_deadline:
-                is_active = page.evaluate(
+                active_title = page.evaluate(
                     f"""
                     (() => {{
+                        // 找视口内 + 无 hp 陷阱 + active 的 tab，取它的 title
                         const tabs = document.querySelectorAll({json.dumps(CREATOR_TAB)});
                         for (const t of tabs) {{
                             if (t.hasAttribute('data-hp-kind') || t.hasAttribute('button-hp-installed')) continue;
+                            if (!t.classList.contains('active')) continue;
+                            const r = t.getBoundingClientRect();
+                            if (r.left < -1000 || r.top < -1000) continue;
                             const title = t.querySelector('span.title');
-                            if (title && title.textContent.trim() === {json.dumps(tab_name)}) {{
-                                return t.classList.contains('active');
-                            }}
+                            return title ? title.textContent.trim() : null;
                         }}
-                        return false;
+                        return null;
                     }})()
                     """
                 )
-                if is_active:
+                if active_title == tab_name:
                     return
                 time.sleep(0.2)
-            logger.warning("点击了 %s 但 active class 未切换，可能被 honey pot 拦截", tab_name)
+            logger.warning(
+                "点击了 %s 但 active tab 仍是 %r，可能被反爬拦截", tab_name, active_title
+            )
 
         if found == "clicked":
             return


### PR DESCRIPTION
## Summary

XHS 反爬升级，老 publish 代码 click-publish 完全静默不发布。3 commits 全面修复：

- **`click_publish_button` 改用 `host.dispatchEvent(new CustomEvent('publish'))`** —— XHS 把发布按钮包成 `<xhs-publish-btn>` Vue web component + **closed shadow DOM**，host 上挂着 `publish` 自定义事件。直接 dispatchEvent 比坐标点击 + CDP 真鼠标更可靠：不依赖坐标、不依赖 chrome.debugger（不会卡 90s）、不被反爬鼠标指纹检测
- **`_click_publish_tab` 用 `data-hp-bound="1"` 识别真 tab** —— XHS 给每个 tab 渲染 3 份（屏外诱饵无属性、honey pot 带 `data-hp-kind`、真 tab 带 `data-hp-bound="1"`），老代码点的是屏外诱饵，导致老的"active class 未切换"假警报。新逻辑要求 `data-hp-bound="1"` + 视口内 + 无 hp 陷阱属性
- **4 层响应捕获 first-wins**：XHR/fetch 内容标志（`HTTPBizError` / `-913x` code / `禁止发笔记` / `note_id`）+ `console.error/.log/.warn` hook + DOM `MutationObserver` toast 关键词。XHS 自家 XHR 拦截层嵌套（s1-main / interceptor.js / axios）让 wrapper 漏响应，**console hook 实测捕获 -9136 风控**
- **`AccountRiskControlError`** 异常包装风控业务码（-913x），CLI 风控时正确返回 `exit 2` + `success: false`
- **`content.js` 加 `chrome.runtime?.id` 守卫** —— 扩展 reload 后老 content script 仍挂在页面，`sendMessage` 同步抛 `Extension context invalidated`（`.catch` 抓不到），加 runtime ID 检测 + try/catch 兜底

## Test plan

- [x] `fill-publish` 跑通，honey pot 假警报消失
- [x] `click-publish` 触发 dispatchEvent，console hook 命中 `code=-9136 msg='因违反社区规范禁止发笔记'`
- [x] CLI 风控时返回 `exit 2` + `{"success": false, "error": "账号被风控（code=-9136）：..."}`
- [x] `python -c "from xhs import errors, publish, bridge"` import 通过
- [x] `node -c extension/{background,content}.js` 语法通过
- [ ] 解封/换账号验证 happy path（`code: 0` 走"发布成功"分支）
- [ ] 扩展 reload 后 console 不再抛 `Extension context invalidated`

🤖 Generated with [Claude Code](https://claude.com/claude-code)