### PR TITLE
feat(media): get-feed-detail 支持提取视频直链并下载到本地

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -217,3 +217,6 @@ comment.txt
 
 # Ralph Loop state
 .claude/.ralph-loop.local.md
+
+# 媒体下载 / 运行时产物
+output/

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -278,7 +278,9 @@ def cmd_wait_login(args: argparse.Namespace) -> None:
         _output(
             {
                 "logged_in": success,
-                "message": "登录成功" if success else "等待超时，请重新运行 get-qrcode 获取新二维码",
+                "message": "登录成功"
+                if success
+                else "等待超时，请重新运行 get-qrcode 获取新二维码",
             },
             exit_code=0 if success else 2,
         )
@@ -324,13 +326,15 @@ def cmd_send_code(args: argparse.Namespace) -> None:
         if not sent:
             _output({"logged_in": True, "message": "已登录，无需重新登录"})
             return
-        _output({
-            "status": "code_sent",
-            "message": (
-                f"验证码已发送至 {args.phone[:3]}****{args.phone[-4:]}，"
-                "请运行 verify-code --code <验证码>"
-            ),
-        })
+        _output(
+            {
+                "status": "code_sent",
+                "message": (
+                    f"验证码已发送至 {args.phone[:3]}****{args.phone[-4:]}，"
+                    "请运行 verify-code --code <验证码>"
+                ),
+            }
+        )
     except RateLimitError:
         _qrcode_fallback(browser, page, args)
     finally:
@@ -420,7 +424,19 @@ def cmd_get_feed_detail(args: argparse.Namespace) -> None:
             config=config,
             keyword=getattr(args, "keyword", "篮球"),
         )
-        _output(detail.to_dict())
+        result = detail.to_dict()
+        save_media = getattr(args, "save_media", None)
+        note_video = result.get("note", {}).get("video") or {}
+        if save_media and note_video.get("url"):
+            from xhs.errors import MediaDownloadError
+            from xhs.media import download_video
+
+            try:
+                path = download_video(note_video["url"], save_media, args.feed_id)
+                note_video["localPath"] = str(path)
+            except MediaDownloadError as e:
+                note_video["downloadError"] = str(e)
+        _output(result)
     except Exception as e:
         # 附带 404 诊断事件，帮助定位根因
         diagnostics: list = []
@@ -580,7 +596,14 @@ def cmd_fill_publish(args: argparse.Namespace) -> None:
                 visibility=args.visibility or "",
             ),
         )
-        _output({"success": True, "title": title, "images": len(image_paths), "status": "表单已填写，等待确认发布"})
+        _output(
+            {
+                "success": True,
+                "title": title,
+                "images": len(image_paths),
+                "status": "表单已填写，等待确认发布",
+            }
+        )
     finally:
         browser.close()
 
@@ -608,7 +631,14 @@ def cmd_fill_publish_video(args: argparse.Namespace) -> None:
                 visibility=args.visibility or "",
             ),
         )
-        _output({"success": True, "title": title, "video": args.video, "status": "视频表单已填写，等待确认发布"})
+        _output(
+            {
+                "success": True,
+                "title": title,
+                "video": args.video,
+                "status": "视频表单已填写，等待确认发布",
+            }
+        )
     finally:
         browser.close()
 
@@ -700,7 +730,13 @@ def cmd_diagnose_404(args: argparse.Namespace) -> None:
 
         events = page.get_404_diagnostics()
         if not events:
-            _output({"success": True, "events": [], "message": "暂无拦截记录，请在小红书页面进行操作后重试"})
+            _output(
+                {
+                    "success": True,
+                    "events": [],
+                    "message": "暂无拦截记录，请在小红书页面进行操作后重试",
+                }
+            )
             return
 
         # 控制台可读报告（写到 stderr）
@@ -711,18 +747,29 @@ def cmd_diagnose_404(args: argparse.Namespace) -> None:
             diag = ev.get("diagnosis", {})
             logger.info(
                 "[%d] %s %s → HTTP %s",
-                i, ev.get("method", "?"), ev.get("url", "?")[:80], ev.get("status", "?"),
+                i,
+                ev.get("method", "?"),
+                ev.get("url", "?")[:80],
+                ev.get("status", "?"),
             )
             logger.info("    根因: %s", diag.get("root_cause", "未知"))
             logger.info("    详情: %s", diag.get("detail", "")[:120])
-            logger.info("    置信: %s | 类别: %s", diag.get("confidence", "?"), diag.get("cause_category", "?"))
-            logger.info("    时间: %s | 页面: %s", ev.get("timestamp", "?"), ev.get("pageUrl", "?")[:60])
+            logger.info(
+                "    置信: %s | 类别: %s",
+                diag.get("confidence", "?"),
+                diag.get("cause_category", "?"),
+            )
+            logger.info(
+                "    时间: %s | 页面: %s", ev.get("timestamp", "?"), ev.get("pageUrl", "?")[:60]
+            )
             cookies = ev.get("cookies", {})
             req = ev.get("request", {})
             logger.info(
                 "    凭证: web_session=%s a1=%s xs=%s xsec_token=%s",
-                cookies.get("has_web_session"), cookies.get("has_a1"),
-                req.get("has_xs"), bool(req.get("xsec_token")),
+                cookies.get("has_web_session"),
+                cookies.get("has_a1"),
+                req.get("has_xs"),
+                bool(req.get("xsec_token")),
             )
             logger.info("─" * 60)
 
@@ -761,19 +808,31 @@ def cmd_get_netlog(args: argparse.Namespace) -> None:
     browser, page = _connect(args)
     try:
         if not page.get_netlog_enabled():
-            print(json.dumps({
-                "error": "netlogger 未启用",
-                "hint": "请打开扩展 popup，标题 XHS Bridge 连点 5 次激活 NetLog 后重试",
-            }, ensure_ascii=False, indent=2))
+            print(
+                json.dumps(
+                    {
+                        "error": "netlogger 未启用",
+                        "hint": "请打开扩展 popup，标题 XHS Bridge 连点 5 次激活 NetLog 后重试",
+                    },
+                    ensure_ascii=False,
+                    indent=2,
+                )
+            )
             sys.exit(2)
 
         entries = page.get_netlog()
         if args.limit:
-            entries = entries[-args.limit:]
-        print(json.dumps({
-            "total": len(entries),
-            "entries": entries,
-        }, ensure_ascii=False, indent=2))
+            entries = entries[-args.limit :]
+        print(
+            json.dumps(
+                {
+                    "total": len(entries),
+                    "entries": entries,
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+        )
     finally:
         browser.close()
 
@@ -785,10 +844,16 @@ def cmd_risk_report(args: argparse.Namespace) -> None:
     browser, page = _connect(args)
     try:
         if not page.get_netlog_enabled():
-            print(json.dumps({
-                "error": "netlogger 未启用",
-                "hint": "请打开扩展 popup，标题 XHS Bridge 连点 5 次激活 NetLog 后重试",
-            }, ensure_ascii=False, indent=2))
+            print(
+                json.dumps(
+                    {
+                        "error": "netlogger 未启用",
+                        "hint": "请打开扩展 popup，标题 XHS Bridge 连点 5 次激活 NetLog 后重试",
+                    },
+                    ensure_ascii=False,
+                    indent=2,
+                )
+            )
             sys.exit(2)
 
         entries = page.get_netlog()
@@ -903,6 +968,11 @@ def build_parser() -> argparse.ArgumentParser:
     sub.add_argument("--max-comment-items", type=int, default=0)
     sub.add_argument("--scroll-speed", default="normal", help="slow|normal|fast")
     sub.add_argument("--keyword", default="篮球", help="风控重试时的搜索关键词")
+    sub.add_argument(
+        "--save-media",
+        metavar="DIR",
+        help="视频笔记时把视频下载到该目录（绝对路径），输出附带 localPath",
+    )
     sub.set_defaults(func=cmd_get_feed_detail)
 
     # user-profile

--- a/scripts/xhs/errors.py
+++ b/scripts/xhs/errors.py
@@ -34,6 +34,14 @@ class PageNotAccessibleError(XHSError):
         super().__init__(f"笔记不可访问: {reason}")
 
 
+class MediaDownloadError(XHSError):
+    """媒体文件下载失败。"""
+
+    def __init__(self, reason: str) -> None:
+        self.reason = reason
+        super().__init__(f"媒体下载失败: {reason}")
+
+
 class UploadTimeoutError(XHSError):
     """上传超时。"""
 

--- a/scripts/xhs/media.py
+++ b/scripts/xhs/media.py
@@ -1,0 +1,69 @@
+"""媒体下载：把小红书视频/图片直链保存到本地。
+
+小红书 CDN 直链带时效签名，需在抓取当下下载；请求需带浏览器 UA 与 referer，
+且禁用本机 SOCKS/HTTP 代理（直连 CDN，避免 python-socks 报错）。
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import requests
+
+from .errors import MediaDownloadError
+
+# 直连 CDN，屏蔽环境里的代理配置
+_NO_PROXIES: dict[str, str] = {"http": "", "https": ""}
+
+_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+    ),
+    "Referer": "https://www.xiaohongshu.com/",
+}
+
+_CHUNK = 1 << 16  # 64 KiB
+
+
+def download_file(url: str, dest: str | Path, *, timeout: float = 60.0) -> Path:
+    """流式下载 url 到 dest（绝对路径），返回落地路径。
+
+    先写入 .part 临时文件，成功后原子重命名，避免半截文件。
+    """
+    if not url:
+        raise MediaDownloadError("直链为空")
+    dest_path = Path(dest)
+    dest_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dest_path.with_suffix(dest_path.suffix + ".part")
+
+    try:
+        with requests.get(
+            url,
+            headers=_HEADERS,
+            stream=True,
+            timeout=timeout,
+            proxies=_NO_PROXIES,
+        ) as resp:
+            resp.raise_for_status()
+            written = 0
+            with open(tmp, "wb") as f:
+                for chunk in resp.iter_content(chunk_size=_CHUNK):
+                    if chunk:
+                        f.write(chunk)
+                        written += len(chunk)
+            if written == 0:
+                raise MediaDownloadError("下载内容为空（0 字节）")
+    except requests.RequestException as e:
+        tmp.unlink(missing_ok=True)
+        raise MediaDownloadError(f"{type(e).__name__}: {e}") from e
+
+    os.replace(tmp, dest_path)
+    return dest_path
+
+
+def download_video(url: str, dest_dir: str | Path, feed_id: str, *, timeout: float = 120.0) -> Path:
+    """下载视频到 dest_dir/<feed_id>.mp4，返回落地路径。"""
+    dest = Path(dest_dir) / f"{feed_id}.mp4"
+    return download_file(url, dest, timeout=timeout)

--- a/scripts/xhs/types.py
+++ b/scripts/xhs/types.py
@@ -170,6 +170,37 @@ class Feed:
 # ========== Feed 详情 ==========
 
 
+# 视频流编码优先级：优先 h264（兼容性最好），其次 h265/av1
+_VIDEO_CODECS = ("h264", "h265", "h266", "av1")
+
+
+def _extract_video(video: dict | None) -> tuple[str, int]:
+    """从 note.video 提取视频直链与时长。
+
+    结构：video.media.stream.{h264|h265|...}[0].masterUrl
+    返回 (masterUrl, duration_seconds)；无视频时返回 ("", 0)。
+    """
+    if not video or not isinstance(video, dict):
+        return "", 0
+    duration = 0
+    capa = video.get("capa")
+    if isinstance(capa, dict):
+        duration = capa.get("duration", 0) or 0
+    stream = ((video.get("media") or {}).get("stream")) or {}
+    for codec in _VIDEO_CODECS:
+        items = stream.get(codec) or []
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            url = item.get("masterUrl") or ""
+            if not url:
+                backups = item.get("backupUrls") or []
+                url = backups[0] if backups else ""
+            if url:
+                return url, duration
+    return "", duration
+
+
 @dataclass
 class DetailImageInfo:
     width: int = 0
@@ -258,7 +289,7 @@ class FeedDetail:
     xsec_token: str = ""
     title: str = ""
     desc: str = ""
-    body: str = ""   # DOM 正文（干净文本，不含 [话题] 标记）
+    body: str = ""  # DOM 正文（干净文本，不含 [话题] 标记）
     tags: list[str] = field(default_factory=list)  # 话题标签列表
     type: str = ""
     time: int = 0
@@ -266,9 +297,12 @@ class FeedDetail:
     user: User = field(default_factory=User)
     interact_info: InteractInfo = field(default_factory=InteractInfo)
     image_list: list[DetailImageInfo] = field(default_factory=list)
+    video_url: str = ""  # 视频直链（masterUrl，带时效签名）
+    video_duration: int = 0  # 视频时长（秒）
 
     @classmethod
     def from_dict(cls, d: dict) -> FeedDetail:
+        video_url, video_duration = _extract_video(d.get("video"))
         return cls(
             note_id=d.get("noteId", ""),
             xsec_token=d.get("xsecToken", ""),
@@ -282,10 +316,12 @@ class FeedDetail:
             user=User.from_dict(d.get("user", {})),
             interact_info=InteractInfo.from_dict(d.get("interactInfo", {})),
             image_list=[DetailImageInfo.from_dict(i) for i in d.get("imageList", []) or []],
+            video_url=video_url,
+            video_duration=video_duration,
         )
 
     def to_dict(self) -> dict:
-        return {
+        result = {
             "noteId": self.note_id,
             "title": self.title,
             "desc": self.desc,
@@ -315,6 +351,12 @@ class FeedDetail:
                 for img in self.image_list
             ],
         }
+        if self.video_url:
+            result["video"] = {
+                "url": self.video_url,
+                "duration": self.video_duration,
+            }
+        return result
 
 
 @dataclass


### PR DESCRIPTION
- types.py: FeedDetail 解析 note.video.media.stream，按 h264>h265>av1 优先级提取 masterUrl 直链与时长，to_dict 输出 video 字段
- media.py: 新增流式下载模块，.part 临时文件原子落地，直连 CDN 绕过本机代理，带浏览器 UA + referer 规避 CDN 防盗链
- cli.py: get-feed-detail 加 --save-media 参数，视频笔记下载到指定目录 并回填 localPath
- errors.py: 新增 MediaDownloadError
- gitignore: 忽略 output/ 运行时产物
  ## 用法
  ```bash
  python scripts/cli.py get-feed-detail --feed-id <ID> --save-media
  /abs/path/to/dir
  ```
  
  ## 验证
  - `ruff check` 新增文件全部通过
  - 导入烟测通过；`_extract_video` 覆盖多编码 fallback 与 backupUrls