### PR TITLE
fix(extension): 导航后校验落地页, 非小红书页面抛明确错误而非 manifest 权限报错

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -536,9 +536,18 @@ async function cmdNavigate({ url, _retried = false }) {
 
   await waitForTabComplete(tab.id, url, 60000);
 
-  // ── 最终落地 URL 检测：XHS 风控 302 重定向到 /404?source=原路径 ──
+  // ── 落地页校验 ─────────────────────────────────────────────
+  // 导航超时/网络失败时 tab 会停在 chrome-error:// 等非小红书页面，
+  // 后续 executeScript 会抛费解的 "Cannot access contents of the page.
+  // Extension manifest must request permission..."（其实是 tab 不在授权 host 上）。
+  // 这里提前判明并抛出明确、可重试的错误，让 Python 侧按"导航失败"处理。
   const finalTab = await chrome.tabs.get(tab.id).catch(() => null);
   const finalUrl = finalTab?.url || "";
+  if (!finalUrl || !/^https?:\/\/([^/]*\.)?xiaohongshu\.com\//.test(finalUrl)) {
+    throw new Error(`页面导航失败: 落地页不可访问 (${finalUrl || "空"})`);
+  }
+
+  // ── 最终落地 URL 检测：XHS 风控 302 重定向到 /404?source=原路径 ──
   if (/xiaohongshu\.com\/404(\?|$)/.test(finalUrl)) {
     // 优先使用 webRequest 观测器已存储的诊断（捕获的是第一跳 302，最准确）
     // webRequest 事件写入是异步的，稍等一下确保已落盘


### PR DESCRIPTION
## 问题

导航超时 / 网络失败时，tab 会停在 `chrome-error://` 等**非小红书页面**。此时后续的
`chrome.scripting.executeScript`（`wait_dom_stable` / `evaluate`）会抛出费解的错误：

```
Cannot access contents of the page. Extension manifest must request permission to access the respective host.
```

这串报错会一路冒泡成 `search-feeds` / `get-feed-detail` 的失败，让人误以为是扩展缺 host 权限，
**真实原因是 tab 不在授权 host 上**（落在了 Chrome 错误页）。

## 根因

`cmdNavigate()` 里 `waitForTabComplete()` 只在 `status === "complete"` 时返回——而导航失败落到
`chrome-error://chromewebdata/` 时该状态同样是 `complete`。于是 navigate 被当成成功，错误延后到
下一步 executeScript 才以「manifest 权限」的形式暴露。

## 修复

`cmdNavigate()` 在 `waitForTabComplete()` 之后校验落地页 URL：非 `xiaohongshu.com` 页面立即抛明确、
可重试的错误：

```
页面导航失败: 落地页不可访问 (<url>)
```

这样 Python 侧（`feed_detail.py` 已有 3 次重试）能按「导航失败」正确重试，而不是拿到费解的权限报错。

## 验证

- 小红书监控实跑中复现：导航超时后，报错从 `Cannot access contents of the page...` 变为明确的
  `页面导航失败: 落地页不可访问 (chrome-error://...)`。
- `node --check extension/background.js` 通过。
